### PR TITLE
fix(styles): fix interface import path

### DIFF
--- a/packages/styles/src/index.ts
+++ b/packages/styles/src/index.ts
@@ -9,3 +9,4 @@ export { IOverlay } from "./tokens/overlay/IOverlay";
 export { ISpacing } from "./tokens/spacing/ISpacing";
 export { IRadius } from "./tokens/radius/IRadius";
 export { IFont } from "./tokens/fontSize/IFont";
+export { ISizes } from "./tokens/sizes/ISizes";

--- a/packages/styles/src/themes/ITheme.ts
+++ b/packages/styles/src/themes/ITheme.ts
@@ -1,9 +1,11 @@
 import { fontSize } from "../tokens/fontSize";
-import { IAvatarSizes } from "../tokens/avatarSizes/IAvatarSizes";
-import { IIconSizes } from "../tokens/iconSizes/IIconSizes";
-import { IButtonSizes } from "../tokens/buttonSizes/IButtonSizes";
-import { IElevation } from "../tokens/elevation/IElevation";
-import { ISizes } from "../tokens/sizes/ISizes";
+import {
+  IAvatarSizes,
+  IIconSizes,
+  IButtonSizes,
+  IElevation,
+  ISizes
+} from "../";
 
 type ITypography = {
   fontFamily?: string;
@@ -48,7 +50,7 @@ export interface ITheme {
       light?: string;
       dark?: string;
       contrastText?: string;
-    },
+    };
     error?: {
       main: string;
       light?: string;

--- a/packages/styles/src/themes/ITheme.ts
+++ b/packages/styles/src/themes/ITheme.ts
@@ -1,9 +1,9 @@
 import { fontSize } from "../tokens/fontSize";
 import { IAvatarSizes } from "../tokens/avatarSizes/IAvatarSizes";
 import { IIconSizes } from "../tokens/iconSizes/IIconSizes";
-import { IButtonSizes } from "tokens/buttonSizes/IButtonSizes";
-import { IElevation } from "tokens/elevation/IElevation";
-import { ISizes } from "tokens/sizes/ISizes";
+import { IButtonSizes } from "../tokens/buttonSizes/IButtonSizes";
+import { IElevation } from "../tokens/elevation/IElevation";
+import { ISizes } from "../tokens/sizes/ISizes";
 
 type ITypography = {
   fontFamily?: string;

--- a/packages/web/src/Components/InputStateHelpTextProvider.tsx
+++ b/packages/web/src/Components/InputStateHelpTextProvider.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
-import { IThemeWeb } from 'Themes';
-import { tokens } from '@naturacosmeticos/natds-styles';
+import { ITheme, tokens } from '@naturacosmeticos/natds-styles';
 import ErrorIcon from '@material-ui/icons/HighlightOffOutlined';
 import SuccessIcon from '@material-ui/icons/CheckCircleOutline';
 
@@ -9,7 +8,7 @@ import { getProp, getColorByState, stateStyles } from './TextField/shared';
 
 export interface IInputStateHelpTextProviderProps {
   id?: string;
-  theme?: IThemeWeb;
+  theme?: ITheme;
   label?: string;
   helpText?: string;
   required?: boolean;

--- a/packages/web/src/Themes/index.ts
+++ b/packages/web/src/Themes/index.ts
@@ -2,11 +2,14 @@ import {
   themes as styleThemes,
   ITheme,
   IFont,
+  IElevation
 } from '@naturacosmeticos/natds-styles';
 import { createMuiTheme } from '@material-ui/core/styles';
+import { Shadows as IShadows } from '@material-ui/core/styles/shadows';
 
 export interface IThemeWeb
-  extends Pick<ITheme, 'shape' | 'palette' | 'avatarSizes' | 'shadows' | 'sizes'> {
+  extends Pick<ITheme, 'shape' | 'palette' | 'avatarSizes' | 'sizes'> {
+  shadows?: IShadows;
   typography: {
     fontFamily?: string;
     fontFamilyBrand1?: string;
@@ -32,8 +35,8 @@ export interface IThemeWeb
   };
 }
 
-function parseShadows(shadows: any): any[] {
-  const outShadows: any[] = [];
+function parseShadows(shadows: IElevation): IShadows {
+  const outShadows: any = [];
 
   createMuiTheme({}).shadows.forEach((shadow, index) => {
     if (shadows[index.toString()]) outShadows.push(shadows[index.toString()]);


### PR DESCRIPTION
affects: @naturacosmeticos/natds-styles

# Description

The import path of some interfaces is broken on the current version of the lib, this makes typescript users unable to use the ITheme inteface and have all the nice features that come with it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested locally with npm link

**Test Configuration**:
* Node version: X.Y.Z
* Yarn version: X.Y.Z

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
