### PR TITLE
chore: ignore icons on publishing

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,9 @@
   "command": {
     "publish": {
       "conventionalCommits": true,
+      "ignoreChanges": [
+        "packages/icons/**"
+      ],
       "message": "chore(release): publish %s via lerna [skip ci]"
     }
   },


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Removes natds-icons from publishing in favor of natds-commons. Without this,  the pipeline will continue to publish natds-icons on every natds-web release.
