### PR TITLE
fix(textField): adds correct boxShadow to Success/Error state

### DIFF
--- a/packages/web/src/Components/Input/Input.styles.ts
+++ b/packages/web/src/Components/Input/Input.styles.ts
@@ -53,6 +53,9 @@ const style = createStyles(
         "&:hover:not(:read-only):not(:disabled):not(:focus)": {
           boxShadow: `${palette?.text?.secondary} 0 0 0 1px`,
         },
+        "&:invalid":{
+          boxShadow,
+        },
         "&::placeholder": {
           color: palette?.text?.secondary,
         },


### PR DESCRIPTION
## Summary

### Proposed changes

Applies the correct boxShadow color to success/error state on TextField when `required` is true.

### Related issue

N/A

### Dependencies added/removed (if applicable)

N/A

---

### Testing

N/A

#### How to test

N/A

#### Test configuration

N/A

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [ ] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [ ] I have made corresponding changes to the documentation (if applicable);
- [ ] My changes generate no new warnings or errors;
