### PR TITLE
perf(natds-web): build only used lodash methods

### DIFF
--- a/packages/web/src/hooks/useDefaultTheme/index.ts
+++ b/packages/web/src/hooks/useDefaultTheme/index.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash'
+import isEqual from 'lodash/isEqual'
 import { ThemeOptions, createMuiTheme, Theme } from '@material-ui/core/styles'
 import useTheme from '@material-ui/core/styles/useTheme'
 import { IThemeWeb, themes } from '../../Themes'


### PR DESCRIPTION
affects: @naturacosmeticos/natds-web

ISSUES CLOSED: #1373

# Description

This PR changes the lodash import so the build step can remove unused lodash stuff.

I've tried using rollup or babel plugins but that doesn't work because the project is being compiled using tsc.

## Type of change

- [ ] Feat: A new feature (non-breaking change which adds functionality)
- [x] Refactor: A code change that neither fixes a bug nor adds a feature
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [ ] Docs: Documentation only changes

# How Has This Been Tested?

I've built my project with this change and it did remove lodash.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors;
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) Guidelines;
