### PR TITLE
chore(natds-web): add instructions to use design tokens from theme

### DIFF
--- a/packages/web/.storybook/main.js
+++ b/packages/web/.storybook/main.js
@@ -8,7 +8,8 @@ const welcomeStories = [
   '../docs/changelog.stories.mdx',
   '../docs/contributing.pt-br.stories.mdx',
   '../docs/troubleshooting.stories.mdx',
-  '../docs/icons.stories.mdx'
+  '../docs/icons.stories.mdx',
+  '../docs/design-tokens.stories.mdx'
 ]
 
 const utilitiesStories = [

--- a/packages/web/docs/design-tokens.md
+++ b/packages/web/docs/design-tokens.md
@@ -1,0 +1,55 @@
+# Using Design Tokens
+
+Design tokens are style properties that allow you to style elements and components in your project, keeping them multi-brand and multi-mode.
+
+## Material UI
+This library is a `natds-web` dependency, so you don't need to install or configure anything, only follow the example:
+
+```javascript
+import { makeStyles, IThemeWeb } from "@naturacosmeticos/natds-web";
+
+const useStyles = makeStyles((theme: IThemeWeb) => ({
+  square: {
+    width: theme.sizes.large,
+    height: theme.sizes.large,
+    backgroundColor: theme.color.primary
+  }
+}));
+
+export const Example = () => {
+  const { square } = useStyles()
+
+  return <div className={square} />
+}
+
+```
+
+## Styled Components
+After installing and configuring [styled components library](https://styled-components.com/), you can replace the `Provider` from `natds-web` to `ThemeProvider` from `styled-components`:
+
+```jsx
+import { buildTheme } from "@naturacosmeticos/natds-web";
+import { ThemeProvider } from "styled-components";
+
+const theme = buildTheme('natura', 'light')
+
+export const App = () => (
+  <ThemeProvider theme={theme}>
+    // your app
+  </ThemeProvider>
+)
+```
+
+So you can access the theme following the example:
+
+```javascript
+import styled from 'styled-components'
+
+const Square = styled.div`
+  height: ${({ theme }) => `${theme.sizes.large}px`};
+  width: ${({ theme }) => `${theme.sizes.large}px`};
+  background-color: ${({ theme }) => theme.color.primary};
+`
+
+export const Example = () => <Square />
+```

--- a/packages/web/docs/design-tokens.stories.mdx
+++ b/packages/web/docs/design-tokens.stories.mdx
@@ -1,0 +1,6 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+import Doc from "./design-tokens.md";
+
+<Meta title="Welcome/Design Tokens" />
+
+<Doc />

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@naturacosmeticos/natds-web",
   "displayName": "NatDS React Web",
   "description": "A collection of components from Natura Design System for React websites and webapps",
-  "version": "4.4.4",
+  "version": "4.4.5-alpha.DSY-2415.3.0",
   "private": false,
   "keywords": [
     "design-system",

--- a/packages/web/src/Provider/Provider.tsx
+++ b/packages/web/src/Provider/Provider.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/destructuring-assignment */
 import {
-  MuiThemeProvider, StylesProvider, createGenerateClassName, createMuiTheme, ThemeOptions
+  MuiThemeProvider, StylesProvider, createGenerateClassName, createTheme, ThemeOptions
 } from '@material-ui/core/styles'
 import * as React from 'react'
 
@@ -17,7 +17,7 @@ export const Provider: React.FunctionComponent<IProviderProps> = ({ cssPrefix, c
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   const theme: ThemeOptions = props.theme ? { ...props.theme } : { ...themes.natura.light }
-  const newTheme = createMuiTheme(theme)
+  const newTheme = createTheme(theme)
 
   const generateClassName = () => createGenerateClassName({
     productionPrefix: cssPrefix || 'natds'

--- a/packages/web/src/Themes/parseShadows.ts
+++ b/packages/web/src/Themes/parseShadows.ts
@@ -1,6 +1,6 @@
 import { IElevation } from '@naturacosmeticos/natds-styles'
 import { Shadows as IShadows } from '@material-ui/core/styles/shadows'
-import { createMuiTheme } from '@material-ui/core/styles'
+import { createTheme } from '@material-ui/core/styles'
 
 type IElevationKey = keyof IElevation;
 
@@ -8,7 +8,7 @@ export const parseShadows = (shadows: IElevation): IShadows => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const outShadows : any = []
 
-  createMuiTheme({}).shadows.forEach((shadow, index) => {
+  createTheme({}).shadows.forEach((shadow, index) => {
     if (shadows[String(index) as IElevationKey]) {
       outShadows.push(shadows[String(index) as IElevationKey])
     } else {

--- a/packages/web/src/hooks/useDefaultTheme/index.test.ts
+++ b/packages/web/src/hooks/useDefaultTheme/index.test.ts
@@ -1,4 +1,4 @@
-import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles'
+import { createTheme, ThemeOptions } from '@material-ui/core/styles'
 import { getDefaultTheme } from '.'
 import { themes } from '../../Themes'
 
@@ -13,9 +13,9 @@ describe('Default theme', () => {
   })
   describe('when provided theme is not from Natura Design System', () => {
     it('should be the Natura Light theme', () => {
-      const actualTheme = createMuiTheme({})
+      const actualTheme = createTheme({})
       const actual = getDefaultTheme(actualTheme)
-      const expectedTheme = createMuiTheme(themes.natura.light as unknown as ThemeOptions)
+      const expectedTheme = createTheme(themes.natura.light as unknown as ThemeOptions)
 
       expect(JSON.stringify(actual)).toBe(JSON.stringify(expectedTheme))
     })

--- a/packages/web/src/hooks/useDefaultTheme/index.ts
+++ b/packages/web/src/hooks/useDefaultTheme/index.ts
@@ -1,4 +1,4 @@
-import { ThemeOptions, createMuiTheme, Theme } from '@material-ui/core/styles'
+import { ThemeOptions, createTheme, Theme } from '@material-ui/core/styles'
 import useTheme from '@material-ui/core/styles/useTheme'
 import { IThemeWeb, themes } from '../../Themes'
 
@@ -7,10 +7,10 @@ const isEqual = (providedTheme: IThemeWeb, defaultTheme: IThemeWeb) => parserToS
 
 export const getDefaultTheme: (providerTheme: IThemeWeb | unknown) => Theme = (providerTheme) => {
   const parsedProviderTheme = JSON.parse(JSON.stringify(providerTheme))
-  const parsedDefaultTheme = JSON.parse(JSON.stringify(createMuiTheme({})))
+  const parsedDefaultTheme = JSON.parse(JSON.stringify(createTheme({})))
 
   if (isEqual(parsedProviderTheme, parsedDefaultTheme)) {
-    return createMuiTheme(themes.natura.light as ThemeOptions)
+    return createTheme(themes.natura.light as ThemeOptions)
   }
 
   return providerTheme as Theme

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,6 +1,7 @@
 import { themes as webThemes } from './Themes'
 
 export const themes = { ...webThemes }
+export { IThemeWeb } from './Themes'
 export { default as Provider, IProviderProps, buildTheme } from './Provider'
 
 export { default as AppBar, IAppBarProps } from './Components/AppBar'


### PR DESCRIPTION
# Description

This PR add instructions to use design tokens from theme, with MaterialUI or Styled-Components. It also fix the IThemeWeb exports and replace CreatMuiTheme to CreateTheme.

## Type of change

- [ ] Feat: A new feature (non-breaking change which adds functionality)
- [x] Refactor: A code change that neither fixes a bug nor adds a feature
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [x] Docs: Documentation only changes

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors;
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) Guidelines;
