### PR TITLE
feat(natds-web): adds size options to set input height

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@naturacosmeticos/natds-web",
   "displayName": "NatDS React Web",
   "description": "A collection of components from Natura Design System for React websites and webapps",
-  "version": "4.4.5",
+  "version": "4.5.0-alpha.DSY-2447.3.0",
   "private": false,
   "keywords": [
     "design-system",

--- a/packages/web/src/Components/Counter/__snapshots__/Counter.test.tsx.snap
+++ b/packages/web/src/Components/Counter/__snapshots__/Counter.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Counter component renders correctly with label: Counter component renders correctly 1`] = `
 <div>
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-11 NatDSInputLabel-root-12 MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-13 NatDSInputLabel-root-14 MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
   >
     some label
@@ -13,7 +13,7 @@ exports[`Counter component renders correctly with label: Counter component rende
     role="group"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root NatDSButton-root-6 MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined NatDSCounter-button-1 NatDSCounter-button-9 MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation Mui-disabled Mui-disabled"
+      className="MuiButtonBase-root MuiButton-root NatDSButton-root-6 MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined NatDSCounter-button-1 NatDSCounter-button-11 MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation Mui-disabled Mui-disabled"
       disabled={true}
       id="decrement-button"
       onBlur={[Function]}
@@ -38,10 +38,10 @@ exports[`Counter component renders correctly with label: Counter component rende
       </span>
     </button>
     <div
-      className="MuiFormControl-root NatDSFormControl-root-8 MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined NatDSCounter-input-2 NatDSCounter-input-10"
+      className="MuiFormControl-root NatDSFormControl-root-8 MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined NatDSCounter-input-2 NatDSCounter-input-12"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInputBase-colorSecondary MuiInput-colorSecondary MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInputBase-root MuiInput-root MuiInputBase-colorSecondary MuiInput-colorSecondary makeStyles-input-9 makeStyles-input-15 MuiInputBase-formControl MuiInput-formControl"
         onClick={[Function]}
         required={false}
         style={
@@ -52,7 +52,7 @@ exports[`Counter component renders correctly with label: Counter component rende
       >
         <input
           aria-invalid={false}
-          className="MuiInputBase-input MuiInput-input MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined NatDSCounter-input-2 NatDSCounter-input-10__input"
+          className="MuiInputBase-input MuiInput-input MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined NatDSCounter-input-2 NatDSCounter-input-12__input"
           disabled={false}
           onAnimationStart={[Function]}
           onBlur={[Function]}
@@ -66,7 +66,7 @@ exports[`Counter component renders correctly with label: Counter component rende
       </div>
     </div>
     <button
-      className="MuiButtonBase-root MuiButton-root NatDSButton-root-6 MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined NatDSCounter-button-1 NatDSCounter-button-9 MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
+      className="MuiButtonBase-root MuiButton-root NatDSButton-root-6 MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined NatDSCounter-button-1 NatDSCounter-button-11 MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation"
       disabled={false}
       id="increment-button"
       onBlur={[Function]}
@@ -132,7 +132,7 @@ exports[`Counter component renders correctly: Counter component renders correctl
       className="MuiFormControl-root NatDSFormControl-root-8 MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined NatDSCounter-input-2 NatDSCounter-input-5"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInputBase-colorSecondary MuiInput-colorSecondary MuiInputBase-formControl MuiInput-formControl"
+        className="MuiInputBase-root MuiInput-root MuiInputBase-colorSecondary MuiInput-colorSecondary makeStyles-input-9 makeStyles-input-10 MuiInputBase-formControl MuiInput-formControl"
         onClick={[Function]}
         required={false}
         style={

--- a/packages/web/src/Components/Field/__snapshots__/Field.test.tsx.snap
+++ b/packages/web/src/Components/Field/__snapshots__/Field.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Field component should match snapshot 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root"
+  className="MuiInputBase-root MuiInput-root makeStyles-input-1 makeStyles-input-2"
   onClick={[Function]}
   required={false}
   style={
@@ -28,7 +28,7 @@ exports[`Field component should match snapshot 1`] = `
 
 exports[`Field component should render input for password types 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root MuiInputBase-adornedEnd"
+  className="MuiInputBase-root MuiInput-root makeStyles-input-1 makeStyles-input-5 MuiInputBase-adornedEnd"
   onClick={[Function]}
   required={false}
   style={
@@ -51,7 +51,7 @@ exports[`Field component should render input for password types 1`] = `
   />
   <svg
     aria-hidden={true}
-    className="MuiSvgIcon-root NatDSPasswordReveal-root-1"
+    className="MuiSvgIcon-root NatDSPasswordReveal-root-6"
     focusable="false"
     onClick={[Function]}
     viewBox="0 0 24 24"
@@ -65,7 +65,7 @@ exports[`Field component should render input for password types 1`] = `
 
 exports[`Field component should render input for search type 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root MuiInputBase-adornedEnd"
+  className="MuiInputBase-root MuiInput-root makeStyles-input-1 makeStyles-input-7 MuiInputBase-adornedEnd"
   onClick={[Function]}
   required={false}
   style={
@@ -88,7 +88,7 @@ exports[`Field component should render input for search type 1`] = `
   />
   <svg
     aria-hidden={true}
-    className="MuiSvgIcon-root NatDSSearchClear-root-2"
+    className="MuiSvgIcon-root NatDSSearchClear-root-8"
     focusable="false"
     viewBox="0 0 24 24"
   >
@@ -101,7 +101,7 @@ exports[`Field component should render input for search type 1`] = `
 
 exports[`Field component should render input for search types and onChange 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root MuiInputBase-adornedEnd"
+  className="MuiInputBase-root MuiInput-root makeStyles-input-1 makeStyles-input-9 MuiInputBase-adornedEnd"
   onClick={[Function]}
   required={false}
   style={
@@ -125,7 +125,7 @@ exports[`Field component should render input for search types and onChange 1`] =
   />
   <svg
     aria-hidden={true}
-    className="MuiSvgIcon-root NatDSSearchClear-root-2"
+    className="MuiSvgIcon-root NatDSSearchClear-root-8"
     focusable="false"
     viewBox="0 0 24 24"
   >
@@ -138,7 +138,7 @@ exports[`Field component should render input for search types and onChange 1`] =
 
 exports[`Field component should render input with maxLength attribute equal 3 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root"
+  className="MuiInputBase-root MuiInput-root makeStyles-input-1 makeStyles-input-10"
   onClick={[Function]}
   required={false}
   style={
@@ -165,7 +165,7 @@ exports[`Field component should render input with maxLength attribute equal 3 1`
 
 exports[`Field component should render single line input 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root"
+  className="MuiInputBase-root MuiInput-root makeStyles-input-1 makeStyles-input-3"
   onClick={[Function]}
   required={false}
   style={
@@ -191,7 +191,7 @@ exports[`Field component should render single line input 1`] = `
 
 exports[`Field component should render single line masked input 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root"
+  className="MuiInputBase-root MuiInput-root makeStyles-input-1 makeStyles-input-4"
   onClick={[Function]}
   required={false}
   style={

--- a/packages/web/src/Components/Input/Input.props.ts
+++ b/packages/web/src/Components/Input/Input.props.ts
@@ -1,4 +1,5 @@
 import { InputProps } from '@material-ui/core/Input'
+import { TextFieldSizes } from '../TextField/TextField.props'
 
 export type Mask = Array<string | RegExp>;
 export type MaskFn = () => Mask | void;
@@ -70,4 +71,10 @@ export interface IInputProps extends Omit<InputProps, OmittedProps> {
    * @type "error" | "success"
    */
   state?: State
+
+  /**
+   * The height of input field
+   * @default mediumX
+   */
+  size?: TextFieldSizes
 }

--- a/packages/web/src/Components/Input/Input.tsx
+++ b/packages/web/src/Components/Input/Input.tsx
@@ -1,23 +1,40 @@
-import MaterialInput from '@material-ui/core/Input'
 import * as React from 'react'
+import { createStyles, makeStyles } from '@material-ui/core'
+import MaterialInput from '@material-ui/core/Input'
+import clsx from 'clsx'
+import { IThemeWeb } from 'Themes'
 import { IInputProps } from './Input.props'
 
 export { IInputProps } from './Input.props'
 
+const styles = makeStyles((theme: IThemeWeb) => createStyles({
+  input: {
+    height: ({ size }: IInputProps) => size && theme.sizes[size],
+    '& .MuiInputBase-input': {
+      minHeight: ({ size }: IInputProps) => size && theme.sizes[size]
+    }
+  }
+}))
+
 export const Input = React.forwardRef<unknown, IInputProps>(
   (props: IInputProps, ref: IInputProps['ref']) => {
     const {
+      className,
       disabled,
       hasIcon,
       multiline,
       rows,
+      size = 'mediumX',
       state,
       ...otherProps
     } = props
 
+    const { input } = styles(props)
+
     return (
       <MaterialInput
         {...otherProps}
+        className={clsx(className, input)}
         data-state={state}
         disabled={disabled}
         multiline={multiline}

--- a/packages/web/src/Components/Input/__snapshots__/Input.test.tsx.snap
+++ b/packages/web/src/Components/Input/__snapshots__/Input.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Input component when hasIcon property is false should match snapshot 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root MuiInput-underline"
+  className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-input-1 makeStyles-input-4"
   onClick={[Function]}
   style={
     Object {
@@ -23,7 +23,7 @@ exports[`Input component when hasIcon property is false should match snapshot 1`
 
 exports[`Input component when hasIcon property is true should match snapshot 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root MuiInput-underline"
+  className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-input-1 makeStyles-input-3"
   onClick={[Function]}
   style={
     Object {
@@ -44,7 +44,7 @@ exports[`Input component when hasIcon property is true should match snapshot 1`]
 
 exports[`Input component when multiline property is explicitly false should match snapshot 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root MuiInput-underline"
+  className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-input-1 makeStyles-input-7"
   onClick={[Function]}
   style={
     Object {
@@ -65,7 +65,7 @@ exports[`Input component when multiline property is explicitly false should matc
 
 exports[`Input component when no props are provided should match snapshot 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root MuiInput-underline"
+  className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-input-1 makeStyles-input-2"
   onClick={[Function]}
   style={
     Object {
@@ -86,7 +86,7 @@ exports[`Input component when no props are provided should match snapshot 1`] = 
 
 exports[`Input component when rows property is set and multiline property is explicitly false should match snapshot 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root MuiInput-underline"
+  className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-input-1 makeStyles-input-9"
   onClick={[Function]}
   style={
     Object {
@@ -108,7 +108,7 @@ exports[`Input component when rows property is set and multiline property is exp
 
 exports[`Input component when rows property is set should match snapshot 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root MuiInput-underline"
+  className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-input-1 makeStyles-input-8"
   onClick={[Function]}
   style={
     Object {
@@ -130,7 +130,7 @@ exports[`Input component when rows property is set should match snapshot 1`] = `
 
 exports[`Input component when state is error should match snapshot 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root MuiInput-underline"
+  className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-input-1 makeStyles-input-5"
   data-state="error"
   onClick={[Function]}
   style={
@@ -152,7 +152,7 @@ exports[`Input component when state is error should match snapshot 1`] = `
 
 exports[`Input component when state is success should match snapshot 1`] = `
 <div
-  className="MuiInputBase-root MuiInput-root MuiInput-underline"
+  className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-input-1 makeStyles-input-6"
   data-state="success"
   onClick={[Function]}
   style={

--- a/packages/web/src/Components/Select/Select.tsx
+++ b/packages/web/src/Components/Select/Select.tsx
@@ -1,12 +1,18 @@
 import * as React from 'react'
 import MaterialSelect from '@material-ui/core/Select'
-import { MenuProps } from '@material-ui/core'
+import { createStyles, makeStyles, MenuProps } from '@material-ui/core'
 import { Icon } from '../Icon'
 import { MenuItem } from '../MenuItem'
 import InputStateHelpTextProvider from '../InputStateHelpTextProvider'
 import {
   DeprecatedOptions, ISelectProps, SelectOptions, UpdatedOptions
 } from './Select.props'
+
+const styles = makeStyles(() => createStyles({
+  select: {
+    marginTop: '0 !important'
+  }
+}))
 
 export { ISelectProps } from './Select.props'
 
@@ -55,6 +61,8 @@ export const Select = React.forwardRef<HTMLSelectElement | HTMLInputElement, ISe
       getContentAnchorEl: null
     }
 
+    const { select } = styles(props)
+
     return (
       <InputStateHelpTextProvider {...rest} state={state}>
         <MaterialSelect
@@ -71,6 +79,7 @@ export const Select = React.forwardRef<HTMLSelectElement | HTMLInputElement, ISe
           ref={ref}
           value={value}
           onBlur={onBlur}
+          className={select}
         >
           {placeholder && (
             <MenuItem value="" disabled>

--- a/packages/web/src/Components/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/web/src/Components/Select/__snapshots__/Select.test.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`Select component should render as disabled 1`] = `
 <div
-  className="MuiFormControl-root NatDSFormControl-root-1"
+  className="MuiFormControl-root NatDSFormControl-root-2"
 >
   <div
-    className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-disabled Mui-disabled MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-select-1 Mui-disabled Mui-disabled MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     options={
       Array [
@@ -46,7 +46,7 @@ exports[`Select component should render as disabled 1`] = `
     />
     <i
       aria-hidden={true}
-      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon Mui-disabled NatDSIcon-root-2 NatDSIcon-root-4"
+      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon Mui-disabled NatDSIcon-root-3 NatDSIcon-root-5"
     />
   </div>
 </div>
@@ -54,10 +54,10 @@ exports[`Select component should render as disabled 1`] = `
 
 exports[`Select component should render as required 1`] = `
 <div
-  className="MuiFormControl-root NatDSFormControl-root-1"
+  className="MuiFormControl-root NatDSFormControl-root-2"
 >
   <div
-    className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-select-1 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     options={
       Array [
@@ -98,7 +98,7 @@ exports[`Select component should render as required 1`] = `
     />
     <i
       aria-hidden={true}
-      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon NatDSIcon-root-2 NatDSIcon-root-12"
+      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon NatDSIcon-root-3 NatDSIcon-root-13"
     />
   </div>
 </div>
@@ -106,10 +106,10 @@ exports[`Select component should render as required 1`] = `
 
 exports[`Select component should render correctly 1`] = `
 <div
-  className="MuiFormControl-root NatDSFormControl-root-1"
+  className="MuiFormControl-root NatDSFormControl-root-2"
 >
   <div
-    className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-select-1 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     options={
       Array [
@@ -149,7 +149,7 @@ exports[`Select component should render correctly 1`] = `
     />
     <i
       aria-hidden={true}
-      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon NatDSIcon-root-2 NatDSIcon-root-3"
+      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon NatDSIcon-root-3 NatDSIcon-root-4"
     />
   </div>
 </div>
@@ -157,10 +157,10 @@ exports[`Select component should render correctly 1`] = `
 
 exports[`Select component should render with helper text 1`] = `
 <div
-  className="MuiFormControl-root NatDSFormControl-root-1"
+  className="MuiFormControl-root NatDSFormControl-root-2"
 >
   <div
-    className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-select-1 MuiInputBase-formControl MuiInput-formControl"
     helpText="Helper Text"
     onClick={[Function]}
     options={
@@ -201,11 +201,11 @@ exports[`Select component should render with helper text 1`] = `
     />
     <i
       aria-hidden={true}
-      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon NatDSIcon-root-2 NatDSIcon-root-5"
+      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon NatDSIcon-root-3 NatDSIcon-root-6"
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-8"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-7 NatDSFormHelperText-root-9"
   >
     Helper Text
   </p>
@@ -214,16 +214,16 @@ exports[`Select component should render with helper text 1`] = `
 
 exports[`Select component should render with label 1`] = `
 <div
-  className="MuiFormControl-root NatDSFormControl-root-1"
+  className="MuiFormControl-root NatDSFormControl-root-2"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-9 NatDSInputLabel-root-10 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-10 NatDSInputLabel-root-11 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-select-1 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     options={
       Array [
@@ -263,7 +263,7 @@ exports[`Select component should render with label 1`] = `
     />
     <i
       aria-hidden={true}
-      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon NatDSIcon-root-2 NatDSIcon-root-11"
+      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon NatDSIcon-root-3 NatDSIcon-root-12"
     />
   </div>
 </div>
@@ -271,10 +271,10 @@ exports[`Select component should render with label 1`] = `
 
 exports[`Select component should render with state error 1`] = `
 <div
-  className="MuiFormControl-root NatDSFormControl-root-1"
+  className="MuiFormControl-root NatDSFormControl-root-2"
 >
   <div
-    className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-select-1 MuiInputBase-formControl MuiInput-formControl"
     data-state="error"
     onClick={[Function]}
     options={
@@ -316,7 +316,7 @@ exports[`Select component should render with state error 1`] = `
     />
     <i
       aria-hidden={true}
-      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon NatDSIcon-root-2 NatDSIcon-root-14"
+      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon NatDSIcon-root-3 NatDSIcon-root-15"
     />
   </div>
 </div>
@@ -324,10 +324,10 @@ exports[`Select component should render with state error 1`] = `
 
 exports[`Select component should render with state success 1`] = `
 <div
-  className="MuiFormControl-root NatDSFormControl-root-1"
+  className="MuiFormControl-root NatDSFormControl-root-2"
 >
   <div
-    className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root MuiInput-underline makeStyles-select-1 MuiInputBase-formControl MuiInput-formControl"
     data-state="success"
     onClick={[Function]}
     options={
@@ -369,7 +369,7 @@ exports[`Select component should render with state success 1`] = `
     />
     <i
       aria-hidden={true}
-      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon NatDSIcon-root-2 NatDSIcon-root-13"
+      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-navigation-arrowbottom MuiSelect-icon NatDSIcon-root-3 NatDSIcon-root-14"
     />
   </div>
 </div>

--- a/packages/web/src/Components/TextField/TextField.argTypes.ts
+++ b/packages/web/src/Components/TextField/TextField.argTypes.ts
@@ -3,6 +3,7 @@ import { ITextFieldProps } from './TextField.props'
 import { booleanArgType } from '../../../.storybook/argTypes/booleanArgType'
 import { types } from './__fixtures__/types'
 import { states } from './__fixtures__/states'
+import { sizes } from './__fixtures__/sizes'
 import { textArgType } from '../../../.storybook/argTypes/textArgType'
 
 const componentArgType = {
@@ -82,6 +83,11 @@ Props like \`rows\` and \`cols\` will be forwarded to the textarea.
   showPasswordIcon: {
     ...componentArgType,
     description: 'Show icon for `password` `type`.'
+  },
+  size: {
+    control: { options: sizes, type: 'inline-radio' },
+    description: 'Sets the height of Input field',
+    defaultValue: 'mediumX'
   },
   state: {
     control: { options: states, type: 'inline-radio' },

--- a/packages/web/src/Components/TextField/TextField.props.ts
+++ b/packages/web/src/Components/TextField/TextField.props.ts
@@ -1,11 +1,13 @@
 import * as React from 'react'
 import { StandardTextFieldProps } from '@material-ui/core'
 import { ISearchClearProps } from 'Components/Field/SearchClear'
+import { ISizes } from '@naturacosmeticos/natds-styles'
 import { IInputStateHelpTextProviderProps } from '../InputStateHelpTextProvider'
 import { IThemeWeb } from '../../Themes'
 import { Mask, MaskFn, State } from '../Input/Input.props'
 
 export type Type = 'password' | 'search' | 'text' | React.InputHTMLAttributes<HTMLInputElement>['type'];
+export type TextFieldSizes = keyof Pick<ISizes, 'semiX' | 'mediumX' | 'medium'>
 
 export interface TextFieldProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -136,6 +138,12 @@ export interface TextFieldProps {
    * The short hint displayed in the input before the user enters a value.
    */
   placeholder?: StandardTextFieldProps['placeholder']
+
+  /**
+   * The height of input field
+   * @default mediumX
+   */
+  size?: TextFieldSizes
 
 }
 

--- a/packages/web/src/Components/TextField/TextField.stories.tsx
+++ b/packages/web/src/Components/TextField/TextField.stories.tsx
@@ -109,3 +109,13 @@ WithMask.args = {
   mask: ['(', /[1-9]/, /\d/, ')', ' ', /\d/, /\d/, /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/],
   placeholder: '(11) 9999-9999'
 }
+
+export const Sizes: Story<ITextFieldProps> = (args) => (
+  <>
+    <TextField {...args} size="semiX" label="SemiX" />
+    &nbsp;
+    <TextField {...args} size="medium" label="Medium" />
+    &nbsp;
+    <TextField {...args} label="MediumX" />
+  </>
+)

--- a/packages/web/src/Components/TextField/__fixtures__/sizes.ts
+++ b/packages/web/src/Components/TextField/__fixtures__/sizes.ts
@@ -1,0 +1,9 @@
+import { TextFieldSizes } from '../TextField.props'
+
+export const sizes: Record<TextFieldSizes, TextFieldSizes> = {
+  semiX: 'semiX',
+  medium: 'medium',
+  mediumX: 'mediumX'
+}
+
+export default sizes

--- a/packages/web/src/Components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/web/src/Components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-30 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-42 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
     htmlFor="field"
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-43 MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
     onClick={[Function]}
     required={false}
     style={
@@ -35,7 +35,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
       type="text"
     />
     <button
-      className="MuiButtonBase-root MuiIconButton-root NatDSCustomIcon-root-27 NatDSCustomIcon-root-31"
+      className="MuiButtonBase-root MuiIconButton-root NatDSCustomIcon-root-39 NatDSCustomIcon-root-44"
       disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
@@ -69,7 +69,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     </button>
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-32"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-45"
   >
     Assistive text
   </p>
@@ -81,14 +81,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-26 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-37 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
     htmlFor="field"
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-38 MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedEnd"
     onClick={[Function]}
     required={false}
     style={
@@ -111,7 +111,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
       type="text"
     />
     <button
-      className="MuiButtonBase-root MuiIconButton-root NatDSCustomIcon-root-27 NatDSCustomIcon-root-28"
+      className="MuiButtonBase-root MuiIconButton-root NatDSCustomIcon-root-39 NatDSCustomIcon-root-40"
       disabled={false}
       onBlur={[Function]}
       onDragLeave={[Function]}
@@ -144,7 +144,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     </button>
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-29"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-41"
   >
     Assistive text
   </p>
@@ -156,14 +156,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-39 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-55 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
     htmlFor="field"
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-56 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     required={false}
     style={
@@ -187,7 +187,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-40"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-57"
   >
     Assistive text
   </p>
@@ -199,14 +199,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-10 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-14 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
     htmlFor="field"
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-15 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     required={false}
     style={
@@ -230,7 +230,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-11"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-16"
   >
     Assistive text
   </p>
@@ -249,7 +249,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-5 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     required={false}
     style={
@@ -273,7 +273,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-6"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-8"
   >
     Assistive text
   </p>
@@ -285,14 +285,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-24 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink Mui-disabled Mui-disabled"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-34 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink Mui-disabled Mui-disabled"
     data-shrink={true}
     htmlFor="field"
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root Mui-disabled Mui-disabled MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-35 Mui-disabled Mui-disabled MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     required={false}
     style={
@@ -316,7 +316,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-25 Mui-disabled"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-36 Mui-disabled"
   >
     Assistive text
   </p>
@@ -328,14 +328,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-18 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink Mui-error Mui-error"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-25 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink Mui-error Mui-error"
     data-shrink={true}
     htmlFor="field"
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-26 MuiInputBase-formControl MuiInput-formControl"
     data-state="error"
     onClick={[Function]}
     required={false}
@@ -360,11 +360,11 @@ exports[`TextField component rendering state should match snapshot - TextField (
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-19 Mui-error"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-27 Mui-error"
   >
     <i
       aria-hidden={true}
-      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-alert-cancel NatDSFormHelperText-icon-5 NatDSIcon-root-16 NatDSIcon-root-20"
+      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-alert-cancel NatDSFormHelperText-icon-7 NatDSIcon-root-23 NatDSIcon-root-28"
     />
     Assistive text
   </p>
@@ -376,14 +376,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-12 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-17 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
     htmlFor="field"
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-18 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     required={false}
     style={
@@ -408,7 +408,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-13"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-19"
   >
     Assistive text
   </p>
@@ -420,14 +420,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-33 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-46 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
     htmlFor="field"
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-47 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     required={false}
     style={
@@ -471,7 +471,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-34"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-48"
   >
     Assistive text
   </p>
@@ -483,14 +483,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-37 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-52 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
     htmlFor="field"
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-53 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     required={false}
     style={
@@ -514,7 +514,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-38"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-54"
   >
     Assistive text
   </p>
@@ -526,14 +526,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-8 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-11 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
     htmlFor="field"
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-12 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     required={false}
     style={
@@ -558,7 +558,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-9"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-13"
   >
     Assistive text
   </p>
@@ -570,14 +570,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-7 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-9 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
     htmlFor="field"
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-10 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     required={false}
     style={
@@ -609,7 +609,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-32 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     required={true}
     style={
@@ -633,7 +633,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-23"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-33"
   >
     Assistive text
   </p>
@@ -645,14 +645,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-21 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-29 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
     htmlFor="field"
   >
     Label *
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-30 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     required={true}
     style={
@@ -676,7 +676,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-22"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-31"
   >
     Assistive text
   </p>
@@ -688,14 +688,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-14 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-20 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
     htmlFor="field"
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-21 MuiInputBase-formControl MuiInput-formControl"
     data-state="success"
     onClick={[Function]}
     required={false}
@@ -720,11 +720,11 @@ exports[`TextField component rendering state should match snapshot - TextField (
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-15"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-22"
   >
     <i
       aria-hidden={true}
-      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-alert-check NatDSFormHelperText-icon-5 NatDSIcon-root-16 NatDSIcon-root-17"
+      className="material-icons MuiIcon-root natds-icons natds-icons-outlined-alert-check NatDSFormHelperText-icon-7 NatDSIcon-root-23 NatDSIcon-root-24"
     />
     Assistive text
   </p>
@@ -736,14 +736,14 @@ exports[`TextField component rendering state should match snapshot - TextField (
   className="MuiFormControl-root NatDSFormControl-root-1"
 >
   <label
-    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-35 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+    className="MuiFormLabel-root MuiInputLabel-root NatDSInputLabel-root-2 NatDSInputLabel-root-49 MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
     data-shrink={true}
     htmlFor="field"
   >
     Label
   </label>
   <div
-    className="MuiInputBase-root MuiInput-root MuiInputBase-formControl MuiInput-formControl"
+    className="MuiInputBase-root MuiInput-root makeStyles-input-4 makeStyles-input-50 MuiInputBase-formControl MuiInput-formControl"
     onClick={[Function]}
     required={false}
     style={
@@ -767,7 +767,7 @@ exports[`TextField component rendering state should match snapshot - TextField (
     />
   </div>
   <p
-    className="MuiFormHelperText-root NatDSFormHelperText-root-4 NatDSFormHelperText-root-36"
+    className="MuiFormHelperText-root NatDSFormHelperText-root-6 NatDSFormHelperText-root-51"
   >
     Assistive text
   </p>


### PR DESCRIPTION
# Description

This PR adds adds size options to set input height and also fix the extra space between the label and input from Select component.

## Type of change

- [x] Feat: A new feature (non-breaking change which adds functionality)
- [ ] Refactor: A code change that neither fixes a bug nor adds a feature
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected
- [ ] Docs: Documentation only changes

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors;
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) Guidelines;
