### PR TITLE
Fix import path for Select and TextField Component

### DIFF
--- a/packages/web/src/Components/Select/Select.props.ts
+++ b/packages/web/src/Components/Select/Select.props.ts
@@ -1,5 +1,5 @@
 import { SelectProps } from '@material-ui/core/Select'
-import { State } from 'Components/Input/Input.props'
+import { State } from '../Input/Input.props'
 
 export type DeprecatedOptions = string | number
 export type UpdatedOptions = { value: string | number; description: string | number }

--- a/packages/web/src/Components/TextField/TextField.props.ts
+++ b/packages/web/src/Components/TextField/TextField.props.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { StandardTextFieldProps } from '@material-ui/core'
-import { ISearchClearProps } from 'Components/Field/SearchClear'
+import { ISearchClearProps } from '../Field/SearchClear'
 import { ISizes } from '@naturacosmeticos/natds-styles'
 import { IInputStateHelpTextProviderProps } from '../InputStateHelpTextProvider'
 import { IThemeWeb } from '../../Themes'


### PR DESCRIPTION
#1645 

# Description
Project type: Typescript (v4.3.5)
Package version: 4.5.4
Webpack version: 4.51.1
Architecture type: Micro Frontend with Single SPA

When running the project build script, the Typescript compiler doesn't complete the action, and to shows the following error: "Cannot find module"
Apparently, in components Select(Select.props.d.ts) and TextField(TextField.props.d.ts) it's not possible to import dependencies without "the absolute path".
I'm using webpack to build the project.

## Type of change

- [ ] feat: new feature for the user, not a new feature for build script
- [x] fix: bug fix for the user, not a fix to a build script
- [ ] docs: changes to the documentation
- [ ] style: formatting, missing semi colons, etc; no production code change
- [ ] refactor: refactoring production code, eg. renaming a variable
- [ ] test: adding missing tests, refactoring tests; no production code   change
- [ ] chore: updating grunt tasks etc; no production code change

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors;
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) Guidelines;