### PR TITLE
refactor(natds-react): remove Icon dependency on IconButton and TextField

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,7 @@
   "name": "@naturacosmeticos/natds-react",
   "displayName": "NatDS-React",
   "description": "A collection of components from Natura Design System for React",
-  "version": "2.21.0",
+  "version": "2.21.1-alpha.DSY-2647.5.0",
   "private": false,
   "keywords": [
     "design-system",

--- a/packages/react/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/Dialog/Dialog.stories.tsx
@@ -7,6 +7,7 @@ import { IconButton } from '../IconButton'
 import { DialogHeader } from './DialogHeader'
 import { DialogBody } from './DialogBody'
 import { DialogFooter } from './DialogFooter'
+import { Icon } from '../Icon'
 
 const componentStatus = `
 ---
@@ -47,9 +48,21 @@ export const Playground: Story<DialogProps> = ({ open, ...args }) => {
       <Dialog {...args} open={showDialog} onEscapeKeyDown={() => setShowDialog(false)}>
         <DialogHeader title="Example" id="dialog-title">
           <div style={{ display: 'flex', gap: 16 }}>
-            <IconButton iconName="outlined-default-mockup" onClick={() => ''} ariaLabel="any icon" />
-            <IconButton iconName="outlined-default-mockup" onClick={() => ''} ariaLabel="any icon" />
-            <IconButton iconName="outlined-default-mockup" onClick={() => ''} ariaLabel="any icon" />
+            <IconButton
+              onClick={() => ''}
+              ariaLabel="any icon"
+              IconComponent={<Icon name="outlined-default-mockup" color="highEmphasis" />}
+            />
+            <IconButton
+              onClick={() => ''}
+              ariaLabel="any icon"
+              IconComponent={<Icon name="outlined-default-mockup" color="highEmphasis" />}
+            />
+            <IconButton
+              onClick={() => ''}
+              ariaLabel="any icon"
+              IconComponent={<Icon name="outlined-default-mockup" color="highEmphasis" />}
+            />
           </div>
         </DialogHeader>
         <DialogBody showDivider>

--- a/packages/react/src/components/IconButton/IconButton.props.ts
+++ b/packages/react/src/components/IconButton/IconButton.props.ts
@@ -1,4 +1,3 @@
-import { IconName } from '@naturacosmeticos/natds-icons'
 import { Color, Size } from '@naturacosmeticos/natds-themes'
 
 export type IconButtonColors = keyof Pick<Color, 'highEmphasis' | 'primary' | 'surface'>

--- a/packages/react/src/components/IconButton/IconButton.props.ts
+++ b/packages/react/src/components/IconButton/IconButton.props.ts
@@ -22,23 +22,15 @@ export interface IconButtonProps {
   className?: string
 
   /**
-   * The icon color
-   * @default highEmphasis
-   */
-  color?: IconButtonColors
-
-  /**
    * If `true`, the icon button will be disabled.
    * @default false
    */
   disabled?: boolean
 
   /**
-   * Set the icon to be rendered.
-   * Check all available names in [Icon Library](https://ds.natura.design/28db352be/p/94367e-icon-library/b/6154b9)
-   * @default outlined-default-mockup
+   * Element to be rendered inside the IconButton.
    */
-  iconName: IconName
+  IconComponent: React.ReactElement;
 
   /**
    * The click handler

--- a/packages/react/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/react/src/components/IconButton/IconButton.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Story, Meta } from '@storybook/react'
 import { IconButton, IconButtonProps } from '.'
 import StoryContainer from '../../helpers/StoryContainer'
+import { Icon } from '../Icon'
 
 const componentStatus = `
 ---
@@ -35,23 +36,45 @@ export default {
 } as Meta
 
 export const Playground: Story<IconButtonProps> = (args) => <IconButton {...args} onClick={() => console.log('clicked!')} />
-Playground.args = { iconName: 'outlined-default-mockup' }
+Playground.args = {
+  IconComponent: <Icon size="standard" name="outlined-default-mockup" color="highEmphasis" />
+}
 
 export const Color: Story<IconButtonProps> = (args) => (
   <StoryContainer>
     <IconButton {...args} />
-    <IconButton {...args} color="primary" />
-    <IconButton {...args} color="surface" />
+    <IconButton
+      {...args}
+      IconComponent={<Icon size="standard" name="outlined-default-mockup" color="primary" />}
+    />
+    <IconButton
+      {...args}
+      IconComponent={<Icon size="standard" name="outlined-default-mockup" color="surface" />}
+    />
   </StoryContainer>
 )
+Color.args = {
+  ...Playground.args
+}
 
 export const Size: Story<IconButtonProps> = (args) => (
   <StoryContainer>
     <IconButton {...args} />
-    <IconButton {...args} size="semiX" />
-    <IconButton {...args} size="medium" />
+    <IconButton
+      {...args}
+      size="semiX"
+      IconComponent={<Icon size="semi" name="outlined-default-mockup" color="highEmphasis" />}
+    />
+    <IconButton
+      {...args}
+      size="medium"
+      IconComponent={<Icon size="semiX" name="outlined-default-mockup" color="highEmphasis" />}
+    />
   </StoryContainer>
 )
+Size.args = {
+  ...Playground.args
+}
 
 export const BackgroundStyle: Story<IconButtonProps> = (args) => (
   <StoryContainer>
@@ -60,12 +83,26 @@ export const BackgroundStyle: Story<IconButtonProps> = (args) => (
     <IconButton {...args} backgroundStyle="overlay" />
   </StoryContainer>
 )
+BackgroundStyle.args = {
+  ...Playground.args
+}
 
 export const Disabled: Story<IconButtonProps> = (args) => (
   <StoryContainer>
-    <IconButton {...args} />
-    <IconButton {...args} backgroundStyle="float" />
-    <IconButton {...args} backgroundStyle="overlay" />
+    <IconButton
+      {...args}
+      IconComponent={<Icon size="standard" name="outlined-default-mockup" color="mediumEmphasis" />}
+    />
+    <IconButton
+      {...args}
+      backgroundStyle="float"
+      IconComponent={<Icon size="standard" name="outlined-default-mockup" color="mediumEmphasis" />}
+    />
+    <IconButton
+      {...args}
+      backgroundStyle="overlay"
+      IconComponent={<Icon size="standard" name="outlined-default-mockup" color="lowEmphasis" />}
+    />
   </StoryContainer>
 )
 Disabled.args = { ...Playground.args, disabled: true }

--- a/packages/react/src/components/IconButton/IconButton.test.tsx
+++ b/packages/react/src/components/IconButton/IconButton.test.tsx
@@ -1,126 +1,94 @@
 import * as React from 'react'
 import { fireEvent } from '@testing-library/react'
+import { Size, Color } from '@naturacosmeticos/natds-themes'
 import renderWithTheme from '../../helpers/renderWithTheme'
-import { IconButtonProps } from './IconButton.props'
 import IconButton from '.'
 import Icon from '../Icon'
+import { IconButtonSize } from './IconButton.props'
 
-const iconButtonProps: IconButtonProps = {
-  IconComponent: <Icon size="standard" name="outlined-default-mockup" color="highEmphasis" />,
-  onClick: () => '',
-  ariaLabel: ''
+type IconButtonTestProps = {
+  iconSize?: keyof Size
+  iconColor?: keyof Color
+  onClick?: () => void
+  disabled?: boolean
+  testID?: string
+  backgroundStyle?: 'none' | 'float' | 'overlay'
+  size?: IconButtonSize
+}
+
+const renderIconButton = (props: IconButtonTestProps) => {
+  const { iconSize = 'standard', iconColor = 'highEmphasis', ...rest } = props
+
+  return (
+    <IconButton
+      IconComponent={<Icon size={iconSize} name="outlined-default-mockup" color={iconColor as keyof Color} />}
+      onClick={() => ({})}
+      ariaLabel=""
+      {...rest}
+    />
+  )
 }
 
 describe('Icon Button component', () => {
   it('should render correctly with default props', () => {
-    const { styles, component } = renderWithTheme(<IconButton {...iconButtonProps} />)
+    const { styles, component } = renderWithTheme(renderIconButton({}))
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should call onClick', () => {
     const onClickMock = jest.fn()
-    const { component: { getByTestId } } = renderWithTheme(<IconButton {...iconButtonProps} onClick={onClickMock} testID="btn-test" />)
+    const { component: { getByTestId } } = renderWithTheme(renderIconButton({ testID: 'btn-test', onClick: onClickMock }))
 
     fireEvent.click(getByTestId('btn-test'))
 
     expect(onClickMock).toHaveBeenCalled()
   })
   it('should render correctly when is disabled', () => {
-    const { styles, component } = renderWithTheme(
-      <IconButton
-        {...iconButtonProps}
-        disabled
-        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="mediumEmphasis" />}
-      />
-    )
+    const { styles, component } = renderWithTheme(renderIconButton({ iconColor: 'mediumEmphasis', disabled: true }))
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the backgroundStyle is float', () => {
-    const { styles, component } = renderWithTheme(
-      <IconButton
-        {...iconButtonProps}
-        backgroundStyle="float"
-        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="highEmphasis" />}
-      />
-    )
+    const { styles, component } = renderWithTheme(renderIconButton({ backgroundStyle: 'float' }))
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the backgroundStyle is float and is disabled', () => {
     const { styles, component } = renderWithTheme(
-      <IconButton
-        {...iconButtonProps}
-        backgroundStyle="float"
-        disabled
-        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="mediumEmphasis" />}
-      />
+      renderIconButton({ backgroundStyle: 'float', disabled: true, iconColor: 'mediumEmphasis' })
     )
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the backgroundStyle is overlay', () => {
-    const { styles, component } = renderWithTheme(
-      <IconButton
-        {...iconButtonProps}
-        backgroundStyle="overlay"
-        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="highEmphasis" />}
-      />
-    )
+    const { styles, component } = renderWithTheme(renderIconButton({ backgroundStyle: 'overlay' }))
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the backgroundStyle is overlay and is disabled', () => {
     const { styles, component } = renderWithTheme(
-      <IconButton
-        {...iconButtonProps}
-        backgroundStyle="overlay"
-        disabled
-        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="lowEmphasis" />}
-      />
+      renderIconButton({ backgroundStyle: 'overlay', disabled: true, iconColor: 'lowEmphasis' })
     )
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the size is semiX', () => {
-    const { styles, component } = renderWithTheme(
-      <IconButton
-        {...iconButtonProps}
-        size="semiX"
-        IconComponent={<Icon size="semi" name="outlined-default-mockup" color="highEmphasis" />}
-      />
-    )
+    const { styles, component } = renderWithTheme(renderIconButton({ size: 'semiX', iconSize: 'semi' }))
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the size is medium', () => {
-    const { styles, component } = renderWithTheme(
-      <IconButton
-        {...iconButtonProps}
-        size="medium"
-        IconComponent={<Icon size="semiX" name="outlined-default-mockup" color="highEmphasis" />}
-      />
-    )
+    const { styles, component } = renderWithTheme(renderIconButton({ size: 'medium', iconSize: 'semiX' }))
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the color is primary', () => {
-    const { styles, component } = renderWithTheme(
-      <IconButton
-        {...iconButtonProps}
-        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="primary" />}
-      />
-    )
+    const { styles, component } = renderWithTheme(renderIconButton({ iconColor: 'primary' }))
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the color is surface', () => {
-    const { styles, component } = renderWithTheme(
-      <IconButton
-        {...iconButtonProps}
-        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="surface" />}
-      />
-    )
+    const { styles, component } = renderWithTheme(renderIconButton({ iconColor: 'surface' }))
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })

--- a/packages/react/src/components/IconButton/IconButton.test.tsx
+++ b/packages/react/src/components/IconButton/IconButton.test.tsx
@@ -3,10 +3,10 @@ import { fireEvent } from '@testing-library/react'
 import renderWithTheme from '../../helpers/renderWithTheme'
 import { IconButtonProps } from './IconButton.props'
 import IconButton from '.'
-import { checkIconColor, getIconSize } from './IconButton'
+import Icon from '../Icon'
 
 const iconButtonProps: IconButtonProps = {
-  iconName: 'outlined-default-mockup',
+  IconComponent: <Icon size="standard" name="outlined-default-mockup" color="highEmphasis" />,
   onClick: () => '',
   ariaLabel: ''
 }
@@ -26,75 +26,102 @@ describe('Icon Button component', () => {
     expect(onClickMock).toHaveBeenCalled()
   })
   it('should render correctly when is disabled', () => {
-    const { styles, component } = renderWithTheme(<IconButton {...iconButtonProps} disabled />)
+    const { styles, component } = renderWithTheme(
+      <IconButton
+        {...iconButtonProps}
+        disabled
+        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="mediumEmphasis" />}
+      />
+    )
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the backgroundStyle is float', () => {
-    const { styles, component } = renderWithTheme(<IconButton {...iconButtonProps} backgroundStyle="float" />)
+    const { styles, component } = renderWithTheme(
+      <IconButton
+        {...iconButtonProps}
+        backgroundStyle="float"
+        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="highEmphasis" />}
+      />
+    )
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the backgroundStyle is float and is disabled', () => {
-    const { styles, component } = renderWithTheme(<IconButton {...iconButtonProps} backgroundStyle="float" disabled />)
+    const { styles, component } = renderWithTheme(
+      <IconButton
+        {...iconButtonProps}
+        backgroundStyle="float"
+        disabled
+        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="mediumEmphasis" />}
+      />
+    )
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the backgroundStyle is overlay', () => {
-    const { styles, component } = renderWithTheme(<IconButton {...iconButtonProps} backgroundStyle="overlay" />)
+    const { styles, component } = renderWithTheme(
+      <IconButton
+        {...iconButtonProps}
+        backgroundStyle="overlay"
+        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="highEmphasis" />}
+      />
+    )
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the backgroundStyle is overlay and is disabled', () => {
-    const { styles, component } = renderWithTheme(<IconButton {...iconButtonProps} backgroundStyle="overlay" disabled />)
+    const { styles, component } = renderWithTheme(
+      <IconButton
+        {...iconButtonProps}
+        backgroundStyle="overlay"
+        disabled
+        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="lowEmphasis" />}
+      />
+    )
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the size is semiX', () => {
-    const { styles, component } = renderWithTheme(<IconButton {...iconButtonProps} size="semiX" />)
+    const { styles, component } = renderWithTheme(
+      <IconButton
+        {...iconButtonProps}
+        size="semiX"
+        IconComponent={<Icon size="semi" name="outlined-default-mockup" color="highEmphasis" />}
+      />
+    )
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the size is medium', () => {
-    const { styles, component } = renderWithTheme(<IconButton {...iconButtonProps} size="medium" />)
+    const { styles, component } = renderWithTheme(
+      <IconButton
+        {...iconButtonProps}
+        size="medium"
+        IconComponent={<Icon size="semiX" name="outlined-default-mockup" color="highEmphasis" />}
+      />
+    )
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the color is primary', () => {
-    const { styles, component } = renderWithTheme(<IconButton {...iconButtonProps} color="primary" />)
+    const { styles, component } = renderWithTheme(
+      <IconButton
+        {...iconButtonProps}
+        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="primary" />}
+      />
+    )
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when the color is surface', () => {
-    const { styles, component } = renderWithTheme(<IconButton {...iconButtonProps} color="surface" />)
+    const { styles, component } = renderWithTheme(
+      <IconButton
+        {...iconButtonProps}
+        IconComponent={<Icon size="standard" name="outlined-default-mockup" color="surface" />}
+      />
+    )
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
-  })
-})
-
-describe('getIconSize', () => {
-  it('should return semiX as icon size', () => {
-    expect(getIconSize('medium')).toBe('semiX')
-  })
-  it('should return semi as icon size', () => {
-    expect(getIconSize('semiX')).toBe('semi')
-  })
-  it('should return standard as icon size', () => {
-    expect(getIconSize('semi')).toBe('standard')
-  })
-})
-
-describe('checkIconColor', () => {
-  it('should return the given color when is not disabled', () => {
-    expect(checkIconColor('none', false, 'primary')).toBe('primary')
-  })
-  it('should return the mediumEmphasis color when is disabled and have backgroundStyle as none', () => {
-    expect(checkIconColor('none', true, 'primary')).toBe('mediumEmphasis')
-  })
-  it('should return the mediumEmphasis color when is disabled and have backgroundStyle as float', () => {
-    expect(checkIconColor('float', true, 'primary')).toBe('mediumEmphasis')
-  })
-  it('should return the mediumEmphasis color when is disabled and have backgroundStyle as overlay', () => {
-    expect(checkIconColor('overlay', true, 'primary')).toBe('lowEmphasis')
   })
 })

--- a/packages/react/src/components/IconButton/IconButton.tsx
+++ b/packages/react/src/components/IconButton/IconButton.tsx
@@ -1,43 +1,19 @@
 import React from 'react'
-import { IconColor, IconSize } from '../Icon/Icon.props'
-import { Icon } from '../Icon'
 import IconButtonBase from './IconButtonBase'
-import { IconButtonColors, IconButtonProps, IconButtonSize } from './IconButton.props'
+import { IconButtonProps } from './IconButton.props'
 import styles from './IconButton.styles'
-
-export const getIconSize = (size: IconButtonSize) => {
-  const iconSize = {
-    medium: 'semiX',
-    semi: 'standard',
-    semiX: 'semi'
-  }
-
-  return iconSize[size]
-}
-
-export const checkIconColor = (
-  backgroundStyle: string, isDisabled: boolean, color: IconButtonColors
-) => {
-  if (isDisabled) {
-    return backgroundStyle === 'overlay' ? 'lowEmphasis' : 'mediumEmphasis'
-  }
-  return color
-}
 
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(({
   ariaLabel,
   backgroundStyle = 'none',
   className = '',
-  color = 'highEmphasis',
   disabled = false,
-  iconName,
+  IconComponent,
   onClick,
   size = 'semi',
   testID
 }, ref) => {
   const { iconButtonContainer } = styles({ disabled, backgroundStyle, size })
-  const iconSize = getIconSize(size) as IconSize
-  const iconColor = checkIconColor(backgroundStyle, disabled, color) as IconColor
 
   return (
     <IconButtonBase
@@ -48,15 +24,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(({
       ref={ref}
       size={size}
       testID={testID}
-      IconComponent={(
-        <Icon
-          ariaHidden
-          color={iconColor}
-          name={iconName}
-          role="button"
-          size={iconSize}
-        />
-      )}
+      IconComponent={IconComponent}
     />
   )
 })

--- a/packages/react/src/components/IconButton/__snapshots__/IconButton.test.tsx.snap
+++ b/packages/react/src/components/IconButton/__snapshots__/IconButton.test.tsx.snap
@@ -2,16 +2,7 @@
 
 exports[`Icon Button component should render correctly when is disabled 1`] = `
 Array [
-  ".icon-0-2-15 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-16 {
-  color: #777777;
-  font-size: 24px;
-}
-.sharedRippleEffect-0-2-5 {
+  ".sharedRippleEffect-0-2-5 {
   top: 0;
   left: 0;
   width: 100%;
@@ -139,6 +130,15 @@ Array [
     background-color: transparent;
     border-radius: 16px;
     width: 32px;
+  }
+  .icon-0-2-15 {
+    font-family: natds-icons;
+    user-select: none;
+    pointer-events: none;
+  }
+  .icon-d0-0-2-16 {
+    color: #777777;
+    font-size: 24px;
   }",
   <div>
     <div
@@ -164,7 +164,7 @@ Array [
           aria-hidden="true"
           class=" icon-0-2-15 icon-d0-0-2-16 natds-icons natds-icons-outlined-default-mockup"
           data-testid="icon-outlined-default-mockup"
-          role="button"
+          role="img"
         />
       </button>
     </div>
@@ -174,16 +174,7 @@ Array [
 
 exports[`Icon Button component should render correctly when the backgroundStyle is float 1`] = `
 Array [
-  ".icon-0-2-15 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-16 {
-  color: #333333;
-  font-size: 24px;
-}
-.sharedRippleEffect-0-2-5 {
+  ".sharedRippleEffect-0-2-5 {
   top: 0;
   left: 0;
   width: 100%;
@@ -314,6 +305,15 @@ Array [
     border-radius: 16px;
     box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.14);
     width: 32px;
+  }
+  .icon-0-2-15 {
+    font-family: natds-icons;
+    user-select: none;
+    pointer-events: none;
+  }
+  .icon-d0-0-2-16 {
+    color: #333333;
+    font-size: 24px;
   }",
   <div>
     <div
@@ -338,7 +338,7 @@ Array [
           aria-hidden="true"
           class=" icon-0-2-15 icon-d0-0-2-16 natds-icons natds-icons-outlined-default-mockup"
           data-testid="icon-outlined-default-mockup"
-          role="button"
+          role="img"
         />
       </button>
     </div>
@@ -348,16 +348,7 @@ Array [
 
 exports[`Icon Button component should render correctly when the backgroundStyle is float and is disabled 1`] = `
 Array [
-  ".icon-0-2-15 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-16 {
-  color: #777777;
-  font-size: 24px;
-}
-.sharedRippleEffect-0-2-5 {
+  ".sharedRippleEffect-0-2-5 {
   top: 0;
   left: 0;
   width: 100%;
@@ -485,6 +476,15 @@ Array [
     background-color: #bbbbbb;
     border-radius: 16px;
     width: 32px;
+  }
+  .icon-0-2-15 {
+    font-family: natds-icons;
+    user-select: none;
+    pointer-events: none;
+  }
+  .icon-d0-0-2-16 {
+    color: #777777;
+    font-size: 24px;
   }",
   <div>
     <div
@@ -510,7 +510,7 @@ Array [
           aria-hidden="true"
           class=" icon-0-2-15 icon-d0-0-2-16 natds-icons natds-icons-outlined-default-mockup"
           data-testid="icon-outlined-default-mockup"
-          role="button"
+          role="img"
         />
       </button>
     </div>
@@ -520,16 +520,7 @@ Array [
 
 exports[`Icon Button component should render correctly when the backgroundStyle is overlay 1`] = `
 Array [
-  ".icon-0-2-15 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-16 {
-  color: #333333;
-  font-size: 24px;
-}
-.sharedRippleEffect-0-2-5 {
+  ".sharedRippleEffect-0-2-5 {
   top: 0;
   left: 0;
   width: 100%;
@@ -660,6 +651,15 @@ Array [
     border-radius: 16px;
     opacity: 0.56;
     width: 32px;
+  }
+  .icon-0-2-15 {
+    font-family: natds-icons;
+    user-select: none;
+    pointer-events: none;
+  }
+  .icon-d0-0-2-16 {
+    color: #333333;
+    font-size: 24px;
   }",
   <div>
     <div
@@ -684,7 +684,7 @@ Array [
           aria-hidden="true"
           class=" icon-0-2-15 icon-d0-0-2-16 natds-icons natds-icons-outlined-default-mockup"
           data-testid="icon-outlined-default-mockup"
-          role="button"
+          role="img"
         />
       </button>
     </div>
@@ -694,16 +694,7 @@ Array [
 
 exports[`Icon Button component should render correctly when the backgroundStyle is overlay and is disabled 1`] = `
 Array [
-  ".icon-0-2-15 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-16 {
-  color: #bbbbbb;
-  font-size: 24px;
-}
-.sharedRippleEffect-0-2-5 {
+  ".sharedRippleEffect-0-2-5 {
   top: 0;
   left: 0;
   width: 100%;
@@ -832,6 +823,15 @@ Array [
     border-radius: 16px;
     opacity: 0.56;
     width: 32px;
+  }
+  .icon-0-2-15 {
+    font-family: natds-icons;
+    user-select: none;
+    pointer-events: none;
+  }
+  .icon-d0-0-2-16 {
+    color: #bbbbbb;
+    font-size: 24px;
   }",
   <div>
     <div
@@ -857,7 +857,7 @@ Array [
           aria-hidden="true"
           class=" icon-0-2-15 icon-d0-0-2-16 natds-icons natds-icons-outlined-default-mockup"
           data-testid="icon-outlined-default-mockup"
-          role="button"
+          role="img"
         />
       </button>
     </div>
@@ -867,16 +867,7 @@ Array [
 
 exports[`Icon Button component should render correctly when the color is primary 1`] = `
 Array [
-  ".icon-0-2-15 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-16 {
-  color: #f4ab34;
-  font-size: 24px;
-}
-.sharedRippleEffect-0-2-5 {
+  ".sharedRippleEffect-0-2-5 {
   top: 0;
   left: 0;
   width: 100%;
@@ -1006,6 +997,15 @@ Array [
     background-color: transparent;
     border-radius: 16px;
     width: 32px;
+  }
+  .icon-0-2-15 {
+    font-family: natds-icons;
+    user-select: none;
+    pointer-events: none;
+  }
+  .icon-d0-0-2-16 {
+    color: #f4ab34;
+    font-size: 24px;
   }",
   <div>
     <div
@@ -1030,7 +1030,7 @@ Array [
           aria-hidden="true"
           class=" icon-0-2-15 icon-d0-0-2-16 natds-icons natds-icons-outlined-default-mockup"
           data-testid="icon-outlined-default-mockup"
-          role="button"
+          role="img"
         />
       </button>
     </div>
@@ -1040,16 +1040,7 @@ Array [
 
 exports[`Icon Button component should render correctly when the color is surface 1`] = `
 Array [
-  ".icon-0-2-15 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-16 {
-  color: #ffffff;
-  font-size: 24px;
-}
-.sharedRippleEffect-0-2-5 {
+  ".sharedRippleEffect-0-2-5 {
   top: 0;
   left: 0;
   width: 100%;
@@ -1179,6 +1170,15 @@ Array [
     background-color: transparent;
     border-radius: 16px;
     width: 32px;
+  }
+  .icon-0-2-15 {
+    font-family: natds-icons;
+    user-select: none;
+    pointer-events: none;
+  }
+  .icon-d0-0-2-16 {
+    color: #ffffff;
+    font-size: 24px;
   }",
   <div>
     <div
@@ -1203,7 +1203,7 @@ Array [
           aria-hidden="true"
           class=" icon-0-2-15 icon-d0-0-2-16 natds-icons natds-icons-outlined-default-mockup"
           data-testid="icon-outlined-default-mockup"
-          role="button"
+          role="img"
         />
       </button>
     </div>
@@ -1213,16 +1213,7 @@ Array [
 
 exports[`Icon Button component should render correctly when the size is medium 1`] = `
 Array [
-  ".icon-0-2-15 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-16 {
-  color: #333333;
-  font-size: 40px;
-}
-.sharedRippleEffect-0-2-5 {
+  ".sharedRippleEffect-0-2-5 {
   top: 0;
   left: 0;
   width: 100%;
@@ -1352,6 +1343,15 @@ Array [
     background-color: transparent;
     border-radius: 24px;
     width: 48px;
+  }
+  .icon-0-2-15 {
+    font-family: natds-icons;
+    user-select: none;
+    pointer-events: none;
+  }
+  .icon-d0-0-2-16 {
+    color: #333333;
+    font-size: 40px;
   }",
   <div>
     <div
@@ -1376,7 +1376,7 @@ Array [
           aria-hidden="true"
           class=" icon-0-2-15 icon-d0-0-2-16 natds-icons natds-icons-outlined-default-mockup"
           data-testid="icon-outlined-default-mockup"
-          role="button"
+          role="img"
         />
       </button>
     </div>
@@ -1386,16 +1386,7 @@ Array [
 
 exports[`Icon Button component should render correctly when the size is semiX 1`] = `
 Array [
-  ".icon-0-2-15 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-16 {
-  color: #333333;
-  font-size: 32px;
-}
-.sharedRippleEffect-0-2-5 {
+  ".sharedRippleEffect-0-2-5 {
   top: 0;
   left: 0;
   width: 100%;
@@ -1525,6 +1516,15 @@ Array [
     background-color: transparent;
     border-radius: 20px;
     width: 40px;
+  }
+  .icon-0-2-15 {
+    font-family: natds-icons;
+    user-select: none;
+    pointer-events: none;
+  }
+  .icon-d0-0-2-16 {
+    color: #333333;
+    font-size: 32px;
   }",
   <div>
     <div
@@ -1549,7 +1549,7 @@ Array [
           aria-hidden="true"
           class=" icon-0-2-15 icon-d0-0-2-16 natds-icons natds-icons-outlined-default-mockup"
           data-testid="icon-outlined-default-mockup"
-          role="button"
+          role="img"
         />
       </button>
     </div>
@@ -1559,16 +1559,7 @@ Array [
 
 exports[`Icon Button component should render correctly with default props 1`] = `
 Array [
-  ".icon-0-2-15 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-16 {
-  color: #333333;
-  font-size: 24px;
-}
-.sharedRippleEffect-0-2-5 {
+  ".sharedRippleEffect-0-2-5 {
   top: 0;
   left: 0;
   width: 100%;
@@ -1698,6 +1689,15 @@ Array [
     background-color: transparent;
     border-radius: 16px;
     width: 32px;
+  }
+  .icon-0-2-15 {
+    font-family: natds-icons;
+    user-select: none;
+    pointer-events: none;
+  }
+  .icon-d0-0-2-16 {
+    color: #333333;
+    font-size: 24px;
   }",
   <div>
     <div
@@ -1722,7 +1722,7 @@ Array [
           aria-hidden="true"
           class=" icon-0-2-15 icon-d0-0-2-16 natds-icons natds-icons-outlined-default-mockup"
           data-testid="icon-outlined-default-mockup"
-          role="button"
+          role="img"
         />
       </button>
     </div>

--- a/packages/react/src/components/Input/Input.props.ts
+++ b/packages/react/src/components/Input/Input.props.ts
@@ -1,4 +1,3 @@
-import { IconName } from '@naturacosmeticos/natds-icons'
 import { Size } from '@naturacosmeticos/natds-themes'
 
 export type InputSize = keyof Pick<Size, 'medium' | 'mediumX'>
@@ -108,11 +107,9 @@ export type InputActionIcon = BaseProps & ({
   action: 'icon'
 
   /**
-   * Set the icon to be rendered.
-   * Check all available names in [Icon Library](https://ds.natura.design/28db352be/p/94367e-icon-library/b/6154b9)
-   * @default outlined-default-mockup
+   * Element to be rendered inside the IconButton.
    */
-  iconName: IconName
+  IconComponent: React.ReactElement;
 
   /**
    * Use to define a text that explains the expected action

--- a/packages/react/src/components/Input/InputAction/InputAction.test.tsx
+++ b/packages/react/src/components/Input/InputAction/InputAction.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import InputAction from '.'
 import renderWithTheme from '../../../helpers/renderWithTheme'
 import { InputActionIcon, InputActionImage, InputProps } from '../Input.props'
+import { Icon } from '../../Icon'
 
 const defaultProps: InputProps = {
   onBlur: () => '',
@@ -13,7 +14,7 @@ const defaultProps: InputProps = {
 const iconProps: InputActionIcon = {
   ...defaultProps,
   action: 'icon',
-  iconName: 'filled-action-rating',
+  IconComponent: <Icon name="filled-action-rating" color="highEmphasis" />,
   onClick: () => '',
   ariaLabel: 'some rating icon button'
 }

--- a/packages/react/src/components/Input/InputAction/InputAction.tsx
+++ b/packages/react/src/components/Input/InputAction/InputAction.tsx
@@ -16,7 +16,7 @@ const InputAction = (props: InputProps): JSX.Element => {
         isIconAction(props)
         && (
           <IconButton
-            iconName={props.iconName}
+            IconComponent={props.IconComponent}
             onClick={props.onClick}
             ariaLabel={props.ariaLabel}
             disabled={props.disabled || props.readOnly}

--- a/packages/react/src/components/Input/InputAction/__snapshots__/InputAction.test.tsx.snap
+++ b/packages/react/src/components/Input/InputAction/__snapshots__/InputAction.test.tsx.snap
@@ -2,16 +2,7 @@
 
 exports[`InputAction component should render an icon button when receive action icon 1`] = `
 Array [
-  ".icon-0-2-20 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-21 {
-  color: #333333;
-  font-size: 24px;
-}
-.sharedRippleEffect-0-2-10 {
+  ".sharedRippleEffect-0-2-10 {
   top: 0;
   left: 0;
   width: 100%;
@@ -157,7 +148,16 @@ Array [
   .container-d0-0-2-4 {
     margin-right: 8px;
   }
-  .wrapper-d1-0-2-5 {  }",
+  .wrapper-d1-0-2-5 {  }
+  .icon-0-2-20 {
+    font-family: natds-icons;
+    user-select: none;
+    pointer-events: none;
+  }
+  .icon-d0-0-2-21 {
+    color: #333333;
+    font-size: 24px;
+  }",
   <div>
     <div
       class="container-0-2-1 container-d0-0-2-4"
@@ -185,7 +185,7 @@ Array [
             aria-hidden="true"
             class=" icon-0-2-20 icon-d0-0-2-21 natds-icons natds-icons-filled-action-rating"
             data-testid="icon-filled-action-rating"
-            role="button"
+            role="img"
           />
         </button>
       </div>

--- a/packages/react/src/components/TextField/TextField.stories.tsx
+++ b/packages/react/src/components/TextField/TextField.stories.tsx
@@ -4,6 +4,7 @@ import { TextField, TextFieldProps } from '.'
 import { Label } from '../Label'
 import { Input, InputHelperText } from '../Input'
 import StoryContainer from '../../helpers/StoryContainer'
+import { Icon } from '../Icon'
 
 const componentStatus = `
 ---
@@ -126,7 +127,7 @@ export const ActionIcon: Story<TextFieldProps> = (args) => (
 ActionIcon.args = {
   ...Playground.args,
   action: 'icon',
-  iconName: 'filled-action-love',
+  IconComponent: <Icon name="filled-action-love" color="highEmphasis" />,
   onClick: () => '',
   ariaLabel: 'heart icon button'
 }

--- a/packages/react/src/components/TextField/TextField.test.tsx
+++ b/packages/react/src/components/TextField/TextField.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import TextField from './TextField'
 import renderWithTheme from '../../helpers/renderWithTheme'
 import { TextFieldProps } from './TextField.props'
+import { Icon } from '../Icon'
 
 const defaultProps: TextFieldProps = {
   onBlur: () => '',
@@ -59,7 +60,16 @@ describe('TextField component', () => {
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })
   it('should render correctly when it has an icon button action', () => {
-    const { styles, component } = renderWithTheme(<TextField {...defaultProps} required action="icon" iconName="filled-action-love" ariaLabel="any label" onClick={() => ''} />)
+    const { styles, component } = renderWithTheme(
+      <TextField
+        {...defaultProps}
+        required
+        action="icon"
+        IconComponent={<Icon name="filled-action-love" color="highEmphasis" />}
+        ariaLabel="any label"
+        onClick={() => ''}
+      />
+    )
 
     expect([styles.toString(), component.container]).toMatchSnapshot()
   })

--- a/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -965,15 +965,6 @@ Array [
 .textArea-d2-0-2-10::placeholder {
   color: #777777;
 }
-.icon-0-2-13 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-14 {
-  color: #569a32;
-  font-size: 16px;
-}
 .helperText-0-2-11 {
   display: flex;
   font-size: 12px;
@@ -991,6 +982,15 @@ Array [
 }
 .helperText-d0-0-2-12 > i {
   margin-right: 4px;
+}
+.icon-0-2-13 {
+  font-family: natds-icons;
+  user-select: none;
+  pointer-events: none;
+}
+.icon-d0-0-2-14 {
+  color: #569a32;
+  font-size: 16px;
 }
 .labelContainer-0-2-3 {
   color: #000000;
@@ -1153,15 +1153,6 @@ Array [
 .textArea-d2-0-2-10::placeholder {
   color: #777777;
 }
-.icon-0-2-13 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-14 {
-  color: #e74627;
-  font-size: 16px;
-}
 .helperText-0-2-11 {
   display: flex;
   font-size: 12px;
@@ -1179,6 +1170,15 @@ Array [
 }
 .helperText-d0-0-2-12 > i {
   margin-right: 4px;
+}
+.icon-0-2-13 {
+  font-family: natds-icons;
+  user-select: none;
+  pointer-events: none;
+}
+.icon-d0-0-2-14 {
+  color: #e74627;
+  font-size: 16px;
 }
 .labelContainer-0-2-3 {
   color: #000000;
@@ -1342,15 +1342,6 @@ Array [
 }
 .textArea-d2-0-2-10::placeholder {
   color: #777777;
-}
-.icon-0-2-30 {
-  font-family: natds-icons;
-  user-select: none;
-  pointer-events: none;
-}
-.icon-d0-0-2-31 {
-  color: #333333;
-  font-size: 24px;
 }
 .sharedRippleEffect-0-2-20 {
   top: 0;
@@ -1517,6 +1508,15 @@ Array [
     color: #777777;
   }
   .helperText-d0-0-2-33 > i {  }
+  .icon-0-2-30 {
+    font-family: natds-icons;
+    user-select: none;
+    pointer-events: none;
+  }
+  .icon-d0-0-2-31 {
+    color: #333333;
+    font-size: 24px;
+  }
   .labelContainer-0-2-3 {
     color: #000000;
     font-family: Helvetica Now Display, Arial;
@@ -1577,7 +1577,7 @@ Array [
                 aria-hidden="true"
                 class=" icon-0-2-30 icon-d0-0-2-31 natds-icons natds-icons-filled-action-love"
                 data-testid="icon-filled-action-love"
-                role="button"
+                role="img"
               />
             </button>
           </div>


### PR DESCRIPTION
# Description

[[Card]](https://natura.atlassian.net/jira/software/c/projects/DSY/boards/1350?modal=detail&selectedIssue=DSY-2647&assignee=60f4c8ff33876e0068b693b2) - Analisando a arquitetura que temos hoje, isso cria uma dependência entre as duas partes que pode inviabilizar algumas atualizações no futuro. A ideia é que os componentes que dependam do Icon possa recebe-lo como uma propriedade.

## Type of change

- [ ] feat: new feature for the user, not a new feature for build script
- [ ] fix: bug fix for the user, not a fix to a build script
- [ ] docs: changes to the documentation
- [ ] style: formatting, missing semi colons, etc; no production code change
- [x] refactor: refactoring production code, eg. renaming a variable
- [ ] test: adding missing tests, refactoring tests; no production code   change
- [ ] chore: updating grunt tasks etc; no production code change

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors;
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) Guidelines;
