### PR TITLE
feat(natds-react): add docs for subcomponents

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,7 @@
   "name": "@naturacosmeticos/natds-react",
   "displayName": "NatDS-React",
   "description": "A collection of components from Natura Design System for React",
-  "version": "2.20.1",
+  "version": "2.21.0-alpha.DSY-2635.1.0",
   "private": false,
   "keywords": [
     "design-system",

--- a/packages/react/src/components/Input/Input.stories.tsx
+++ b/packages/react/src/components/Input/Input.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Story, Meta } from '@storybook/react'
+import { Input, InputProps } from '.'
+
+export default {
+  title: 'Utilities/Input',
+  component: Input,
+  parameters: {
+    previewTabs: {
+      canvas: { hidden: true }
+    }
+  }
+} as Meta
+
+export const Default: Story<InputProps> = (args) => <Input {...args} />
+Default.args = {
+}

--- a/packages/react/src/components/Input/InputHelperText/InputHelperText.stories.tsx
+++ b/packages/react/src/components/Input/InputHelperText/InputHelperText.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Story, Meta } from '@storybook/react'
+import { InputHelperText, InputHelperTextProps } from '.'
+
+export default {
+  title: 'Utilities/InputHelperText',
+  component: InputHelperText,
+  parameters: {
+    previewTabs: {
+      canvas: { hidden: true }
+    }
+  }
+} as Meta
+
+export const Default: Story<InputHelperTextProps> = (args) => <InputHelperText {...args} />
+Default.args = {
+  helperText: 'Helper Text'
+}

--- a/packages/react/src/components/Input/InputHelperText/index.ts
+++ b/packages/react/src/components/Input/InputHelperText/index.ts
@@ -1,4 +1,5 @@
 import InputHelperText from './InputHelperText'
 
+export { InputHelperTextProps } from './InputHelperText.props'
 export { InputHelperText }
 export default InputHelperText

--- a/packages/react/src/components/Label/Label.stories.tsx
+++ b/packages/react/src/components/Label/Label.stories.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Story, Meta } from '@storybook/react'
+import { Label, LabelProps } from '.'
+
+export default {
+  title: 'Utilities/Label',
+  component: Label,
+  parameters: {
+    previewTabs: {
+      canvas: { hidden: true }
+    }
+  }
+} as Meta
+
+export const Default: Story<LabelProps> = (args) => <Label {...args} />
+Default.args = {
+  label: 'label'
+}

--- a/packages/react/src/components/TextField/TextField.stories.tsx
+++ b/packages/react/src/components/TextField/TextField.stories.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react'
 import { Story, Meta } from '@storybook/react'
 import { TextField, TextFieldProps } from '.'
+import { Label } from '../Label'
+import { Input, InputHelperText } from '../Input'
 import StoryContainer from '../../helpers/StoryContainer'
 
 const componentStatus = `
@@ -32,6 +34,7 @@ const componentStatus = `
 export default {
   title: 'Components/TextField',
   component: TextField,
+  subcomponents: { Label, InputHelperText, Input },
   parameters: {
     componentSubtitle: 'Text fields let users enter and edit text',
     docs: { description: { component: componentStatus } },


### PR DESCRIPTION
affects: @naturacosmeticos/natds-react

# Description

This PR adds the subcomponents docs.

## Type of change

- [ ] feat: new feature for the user, not a new feature for build script
- [ ] fix: bug fix for the user, not a fix to a build script
- [ ] docs: changes to the documentation
- [ ] style: formatting, missing semi colons, etc; no production code change
- [ ] refactor: refactoring production code, eg. renaming a variable
- [ ] test: adding missing tests, refactoring tests; no production code   change
- [x] chore: updating grunt tasks etc; no production code change

# Quality Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors;
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) Guidelines;
