### PR TITLE
Dsy 3324 add new logo avon v2 and remove fontes helvetica

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@naturacosmeticos/natds-icons": "1.11.3",
-    "@naturacosmeticos/natds-themes": "0.53.0",
+    "@naturacosmeticos/natds-themes": "0.54.0",
     "react-jss": "10.9.0"
   },
   "devDependencies": {

--- a/packages/react/src/ThemeProvider/__snapshots__/buildTheme.test.ts.snap
+++ b/packages/react/src/ThemeProvider/__snapshots__/buildTheme.test.ts.snap
@@ -76,11 +76,11 @@ Object {
     "font": Object {
       "file": Object {
         "body": Object {
-          "bold": "helvetica_now_display_bd",
-          "regular": "helvetica_now_display_regular",
+          "bold": "roboto_medium",
+          "regular": "roboto_regular",
         },
-        "display": "helvetica_now_display_bd",
-        "headline": "helvetica_now_display_md",
+        "display": "roboto_regular",
+        "headline": "roboto_regular",
       },
     },
   },
@@ -1015,17 +1015,17 @@ Object {
   "typography": Object {
     "body": Object {
       "bold": Object {
-        "fontFamily": "Helvetica Now Text",
+        "fontFamily": "Roboto",
         "fontWeight": 700,
       },
       "regular": Object {
-        "fontFamily": "Helvetica Now Text",
+        "fontFamily": "Roboto",
         "fontWeight": 400,
       },
     },
     "display": Object {
-      "fontFamily": "Helvetica Now Display",
-      "fontWeight": 900,
+      "fontFamily": "Roboto",
+      "fontWeight": 700,
     },
     "fallback": Object {
       "fontFamily": "Arial",
@@ -1061,8 +1061,8 @@ Object {
       "regular": 400,
     },
     "headline": Object {
-      "fontFamily": "Helvetica Now Display",
-      "fontWeight": 700,
+      "fontFamily": "Roboto",
+      "fontWeight": 500,
     },
     "lineHeight": Object {
       "auto": 1,

--- a/packages/react/src/components/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/packages/react/src/components/Alert/__snapshots__/Alert.test.tsx.snap
@@ -23,7 +23,7 @@ Array [
   display: flex;
   padding: 16px;
   background: #D0EBFF;
-  font-family: Helvetica Now Text;
+  font-family: Roboto;
   border-radius: 4px;
 }
 .content-d1-0-2-4 {

--- a/packages/react/src/components/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/components/Autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -9,7 +9,7 @@ Array [
 }
 .labelText-0-2-2 {
   font-size: 14px;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
   font-weight: 500;
   line-height: 1.5;
   margin-bottom: 4px;
@@ -157,7 +157,7 @@ Array [
 }
 .labelText-0-2-2 {
   font-size: 14px;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
   font-weight: 500;
   line-height: 1.5;
   margin-bottom: 4px;
@@ -304,7 +304,7 @@ Array [
 }
 .labelText-0-2-2 {
   font-size: 14px;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
   font-weight: 500;
   line-height: 1.5;
   margin-bottom: 4px;
@@ -451,7 +451,7 @@ Array [
 }
 .labelText-0-2-2 {
   font-size: 14px;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
   font-weight: 500;
   line-height: 1.5;
   margin-bottom: 4px;

--- a/packages/react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -815,7 +815,7 @@ Array [
   }
   .labelContainer-0-2-17 {
     color: #000000;
-    font-family: Helvetica Now Text, Arial;
+    font-family: Roboto, Arial;
   }
   .container-0-2-1 {
     display: flex;

--- a/packages/react/src/components/Counter/__snapshots__/Counter.test.tsx.snap
+++ b/packages/react/src/components/Counter/__snapshots__/Counter.test.tsx.snap
@@ -641,7 +641,7 @@ exports[`Counter should render correctly with label 1`] = `
 Array [
   ".labelContainer-0-2-7 {
   color: #000000;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
 }
 .sharedRippleEffect-0-2-14 {
   top: 0;

--- a/packages/react/src/components/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/packages/react/src/components/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -724,7 +724,7 @@ Array [
   }
   .labelContainer-0-2-17 {
     color: #000000;
-    font-family: Helvetica Now Text, Arial;
+    font-family: Roboto, Arial;
   }
   .wrapper-0-2-1 {
     width: 40px;

--- a/packages/react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -167,7 +167,7 @@ Array [
   }
   .labelContainer-0-2-24 {
     color: #000000;
-    font-family: Helvetica Now Text, Arial;
+    font-family: Roboto, Arial;
   }",
   <div>
     <div
@@ -388,7 +388,7 @@ Array [
   }
   .labelContainer-0-2-24 {
     color: #000000;
-    font-family: Helvetica Now Text, Arial;
+    font-family: Roboto, Arial;
   }",
   <div>
     <div
@@ -766,7 +766,7 @@ Array [
   .rating-d0-0-2-6 {  }
   .labelContainer-0-2-52 {
     color: #000000;
-    font-family: Helvetica Now Text, Arial;
+    font-family: Roboto, Arial;
   }",
   <div>
     <div
@@ -1260,7 +1260,7 @@ Array [
   .rating-d0-0-2-6 {  }
   .labelContainer-0-2-52 {
     color: #000000;
-    font-family: Helvetica Now Text, Arial;
+    font-family: Roboto, Arial;
   }",
   <div>
     <div
@@ -1774,7 +1774,7 @@ Array [
   .rating-d0-0-2-6 {  }
   .labelContainer-0-2-52 {
     color: #000000;
-    font-family: Helvetica Now Text, Arial;
+    font-family: Roboto, Arial;
   }",
   <div>
     <div
@@ -2283,7 +2283,7 @@ Array [
   .rating-d0-0-2-6 {  }
   .labelContainer-0-2-52 {
     color: #000000;
-    font-family: Helvetica Now Text, Arial;
+    font-family: Roboto, Arial;
   }",
   <div>
     <div

--- a/packages/react/src/components/Shortcut/__snapshots__/Shortcut.test.tsx.snap
+++ b/packages/react/src/components/Shortcut/__snapshots__/Shortcut.test.tsx.snap
@@ -305,7 +305,7 @@ Array [
   }
   .labelContainer-0-2-25 {
     color: #000000;
-    font-family: Helvetica Now Text, Arial;
+    font-family: Roboto, Arial;
   }
   .wrapper-0-2-1 {
     width: 56px;
@@ -782,7 +782,7 @@ Array [
   }
   .labelContainer-0-2-20 {
     color: #000000;
-    font-family: Helvetica Now Text, Arial;
+    font-family: Roboto, Arial;
   }
   .wrapper-0-2-1 {
     width: 56px;

--- a/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -129,7 +129,7 @@ Array [
 .helperText-d0-0-2-12 > i {}
 .labelContainer-0-2-3 {
   color: #000000;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
 }
 .labelText-0-2-1 {
   font-size: 14px;
@@ -301,7 +301,7 @@ Array [
 .helperText-d0-0-2-12 > i {}
 .labelContainer-0-2-3 {
   color: #000000;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
 }
 .labelText-0-2-1 {
   font-size: 14px;
@@ -471,7 +471,7 @@ Array [
 .helperText-d0-0-2-12 > i {}
 .labelContainer-0-2-3 {
   color: #000000;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
 }
 .labelText-0-2-1 {
   font-size: 14px;
@@ -641,7 +641,7 @@ Array [
 .helperText-d0-0-2-12 > i {}
 .labelContainer-0-2-3 {
   color: #000000;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
 }
 .labelText-0-2-1 {
   font-size: 14px;
@@ -811,7 +811,7 @@ Array [
 .helperText-d0-0-2-12 > i {}
 .labelContainer-0-2-3 {
   color: #000000;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
 }
 .labelText-0-2-1 {
   font-size: 14px;
@@ -994,7 +994,7 @@ Array [
 }
 .labelContainer-0-2-3 {
   color: #000000;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
 }
 .labelText-0-2-1 {
   font-size: 14px;
@@ -1182,7 +1182,7 @@ Array [
 }
 .labelContainer-0-2-3 {
   color: #000000;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
 }
 .labelText-0-2-1 {
   font-size: 14px;
@@ -1516,7 +1516,7 @@ Array [
   }
   .labelContainer-0-2-3 {
     color: #000000;
-    font-family: Helvetica Now Text, Arial;
+    font-family: Roboto, Arial;
   }
   .labelText-0-2-1 {
     font-size: 14px;
@@ -1735,7 +1735,7 @@ Array [
 .helperText-d0-0-2-17 > i {}
 .labelContainer-0-2-3 {
   color: #000000;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
 }
 .labelText-0-2-1 {
   font-size: 14px;
@@ -1919,7 +1919,7 @@ Array [
 .helperText-d0-0-2-12 > i {}
 .labelContainer-0-2-3 {
   color: #000000;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
 }
 .labelText-0-2-1 {
   font-size: 14px;
@@ -2088,7 +2088,7 @@ Array [
 .helperText-d0-0-2-12 > i {}
 .labelContainer-0-2-3 {
   color: #000000;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
 }
 .labelText-0-2-1 {
   font-size: 14px;
@@ -2258,7 +2258,7 @@ Array [
 .helperText-d0-0-2-12 > i {}
 .labelContainer-0-2-3 {
   color: #000000;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
 }
 .labelText-0-2-1 {
   font-size: 14px;
@@ -2428,7 +2428,7 @@ Array [
 .helperText-d0-0-2-12 > i {}
 .labelContainer-0-2-3 {
   color: #000000;
-  font-family: Helvetica Now Text, Arial;
+  font-family: Roboto, Arial;
 }
 .labelText-0-2-1 {
   font-size: 14px;

--- a/packages/react/src/components/Typography/__snapshots__/Typography.test.tsx.snap
+++ b/packages/react/src/components/Typography/__snapshots__/Typography.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Typography component Body variants should render the component as body1
 Array [
   ".text-0-2-1 {}
 .text-d0-0-2-2 {
-  font-family: Helvetica Now Text;
+  font-family: Roboto;
   font-weight: 400;
   font-size: 16px;
   line-height: 1.5;
@@ -27,7 +27,7 @@ exports[`Typography component Body variants should render the component as body2
 Array [
   ".text-0-2-1 {}
 .text-d0-0-2-2 {
-  font-family: Helvetica Now Text;
+  font-family: Roboto;
   font-weight: 400;
   font-size: 14px;
   line-height: 1.5;
@@ -50,7 +50,7 @@ exports[`Typography component Caption variant should render the component as cap
 Array [
   ".text-0-2-1 {}
 .text-d0-0-2-2 {
-  font-family: Helvetica Now Text;
+  font-family: Roboto;
   font-weight: 400;
   font-size: 12px;
   line-height: 1.5;
@@ -73,7 +73,7 @@ exports[`Typography component Heading variants should render the component as he
 Array [
   ".text-0-2-1 {}
 .text-d0-0-2-2 {
-  font-family: Helvetica Now Display;
+  font-family: Roboto;
   font-weight: 400;
   font-size: 96px;
   line-height: 1.5;
@@ -96,7 +96,7 @@ exports[`Typography component Heading variants should render the component as he
 Array [
   ".text-0-2-1 {}
 .text-d0-0-2-2 {
-  font-family: Helvetica Now Display;
+  font-family: Roboto;
   font-weight: 400;
   font-size: 60px;
   line-height: 1.5;
@@ -119,7 +119,7 @@ exports[`Typography component Heading variants should render the component as he
 Array [
   ".text-0-2-1 {}
 .text-d0-0-2-2 {
-  font-family: Helvetica Now Display;
+  font-family: Roboto;
   font-weight: 400;
   font-size: 48px;
   line-height: 1.5;
@@ -142,7 +142,7 @@ exports[`Typography component Heading variants should render the component as he
 Array [
   ".text-0-2-1 {}
 .text-d0-0-2-2 {
-  font-family: Helvetica Now Display;
+  font-family: Roboto;
   font-weight: 400;
   font-size: 34px;
   line-height: 1.5;
@@ -165,7 +165,7 @@ exports[`Typography component Heading variants should render the component as he
 Array [
   ".text-0-2-1 {}
 .text-d0-0-2-2 {
-  font-family: Helvetica Now Display;
+  font-family: Roboto;
   font-weight: 400;
   font-size: 24px;
   line-height: 1.5;
@@ -188,7 +188,7 @@ exports[`Typography component Heading variants should render the component as he
 Array [
   ".text-0-2-1 {}
 .text-d0-0-2-2 {
-  font-family: Helvetica Now Display;
+  font-family: Roboto;
   font-weight: 500;
   font-size: 20px;
   line-height: 1.5;
@@ -211,7 +211,7 @@ exports[`Typography component Overline variant should render the component as ov
 Array [
   ".text-0-2-1 {}
 .text-d0-0-2-2 {
-  font-family: Helvetica Now Text;
+  font-family: Roboto;
   font-weight: 500;
   font-size: 12px;
   line-height: 1.5;
@@ -234,7 +234,7 @@ exports[`Typography component Subtitle variants should render the component as s
 Array [
   ".text-0-2-1 {}
 .text-d0-0-2-2 {
-  font-family: Helvetica Now Text;
+  font-family: Roboto;
   font-weight: 500;
   font-size: 16px;
   line-height: 1.5;
@@ -257,7 +257,7 @@ exports[`Typography component Subtitle variants should render the component as s
 Array [
   ".text-0-2-1 {}
 .text-d0-0-2-2 {
-  font-family: Helvetica Now Text;
+  font-family: Roboto;
   font-weight: 500;
   font-size: 14px;
   line-height: 1.5;
@@ -280,7 +280,7 @@ exports[`Typography component should render the component as body1 when variant 
 Array [
   ".text-0-2-1 {}
 .text-d0-0-2-2 {
-  font-family: Helvetica Now Text;
+  font-family: Roboto;
   font-weight: 400;
   font-size: 16px;
   line-height: 1.5;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2702,10 +2702,10 @@
     svg2vectordrawable "2.6.26"
     webp-converter "^2.3.3"
 
-"@naturacosmeticos/natds-themes@0.53.0":
-  version "0.53.0"
-  resolved "https://registry.yarnpkg.com/@naturacosmeticos/natds-themes/-/natds-themes-0.53.0.tgz#dd7d168c6bb3aa202f07788853bf7b63f6fb8d59"
-  integrity sha512-zq1SJtyU+hnQATKmMXXiNpH8mAtAEc9H3vqxUAUB7iwGolmZQsY/V4EiQjDiPAJK8GZQ/wUnm2zNXg3+E7mmFw==
+"@naturacosmeticos/natds-themes@0.54.0":
+  version "0.54.0"
+  resolved "https://registry.yarnpkg.com/@naturacosmeticos/natds-themes/-/natds-themes-0.54.0.tgz#58442a8702230fb2da7446cddaf804d5e0e099d0"
+  integrity sha512-bSM+V74alX2P4vfncqJN8k/8vYWMMJRj4dzf2hxmfuhJa5RHfFLqauZjgkgSA2O2zQ5Lfr0RKZYz0zLO5bnesg==
   dependencies:
     open-color "^1.8.0"
     svg2vectordrawable "2.6.26"


### PR DESCRIPTION
affects: @naturacosmeticos/natds-react
 DSY-3324

# Description

add new logo avon v2 and revome fontes helvetica

## Type of change

- [x] feat: new feature for the user, not a new feature for build script
- [ ] fix: bug fix for the user, not a fix to a build script
- [ ] docs: changes to the documentation
- [ ] style: formatting, missing semi colons, etc; no production code change
- [ ] refactor: refactoring production code, eg. renaming a variable
- [ ] test: adding missing tests, refactoring tests; no production code   change
- [ ] chore: updating grunt tasks etc; no production code change

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors;
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) Guidelines;
