### PR TITLE
fix(natds-react):  update themes fixed texttransform CB2 e FV2 to none

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@naturacosmeticos/natds-icons": "1.27.5",
-    "@naturacosmeticos/natds-themes": "0.82.0",
+    "@naturacosmeticos/natds-themes": "0.82.1",
     "react-jss": "10.9.0"
   },
   "devDependencies": {

--- a/packages/react/src/components/GayaButton/GayaButton.stories.tsx
+++ b/packages/react/src/components/GayaButton/GayaButton.stories.tsx
@@ -8,6 +8,8 @@ import { GayaButtonProps } from './GayaButton.props'
 import GayaButton from './GayaButton'
 import StoryContainer from '../../helpers/StoryContainer'
 
+// theme version 0.82.1
+
 const componentStatus = `
 
 > O GaYaButton faz parte da evolução contínua dos componentes do GaYa Design System. Lançado como um novo componente, o GaYaButton substitui o antigo Button, que permanecerá disponível para uso, mas não receberá mais atualizações ou suporte ativo. 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2707,10 +2707,10 @@
     svg2vectordrawable "2.6.26"
     webp-converter "^2.3.3"
 
-"@naturacosmeticos/natds-themes@0.82.0":
-  version "0.82.0"
-  resolved "https://registry.yarnpkg.com/@naturacosmeticos/natds-themes/-/natds-themes-0.82.0.tgz#9a5fe9a777c1606abf5bdba443e08da3ee5fc328"
-  integrity sha512-f4iruRFMURh1tZ86oc6nr7I33OvE510DTUPpT2g2D5SthBJu/idyuE+xBLo9swCYYC4/GjGR0EqQ7vC4LIvJSA==
+"@naturacosmeticos/natds-themes@0.82.1":
+  version "0.82.1"
+  resolved "https://registry.yarnpkg.com/@naturacosmeticos/natds-themes/-/natds-themes-0.82.1.tgz#d451985c44cece007f4f465efe03b1c6fc70dc50"
+  integrity sha512-vI7dp6LMgI71hV7BXdjvCnLJPUiwANkhIZngbHw52ZrKp700qQTBIQlc8BFL4w2zd5kcUhE1j7puzgH+vbg2Gg==
   dependencies:
     open-color "^1.8.0"
     svg2vectordrawable "2.6.26"


### PR DESCRIPTION
affects: @naturacosmeticos/natds-react
DSY-5430

# Description

update themes fixed texttransform CB2 e FV2 to none

## Type of change

- [ ] feat: new feature for the user, not a new feature for build script
- [x] fix: bug fix for the user, not a fix to a build script
- [ ] docs: changes to the documentation
- [ ] style: formatting, missing semi colons, etc; no production code change
- [ ] refactor: refactoring production code, eg. renaming a variable
- [ ] test: adding missing tests, refactoring tests; no production code   change
- [ ] chore: updating grunt tasks etc; no production code change

# Quality Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors;
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) Guidelines;
